### PR TITLE
dird does not need to start after confgend

### DIFF
--- a/debian/wazo-dird.service
+++ b/debian/wazo-dird.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=wazo-dird server
-After=network.target postgresql.service xivo-confgend.service
+After=network.target postgresql.service
 Before=monit.service
 
 [Service]


### PR DESCRIPTION
dird used to call xivo-confgen to get its configuration but not anymore