### PR TITLE
personal: use the uuid from metadata

### DIFF
--- a/integration_tests/suite/test_personal.py
+++ b/integration_tests/suite/test_personal.py
@@ -3,6 +3,8 @@
 
 import unittest
 import kombu
+import uuid
+
 from hamcrest import (
     all_of,
     assert_that,
@@ -15,6 +17,7 @@ from hamcrest import (
     has_item,
     has_items,
     has_key,
+    has_properties,
     is_,
     none,
     not_,
@@ -86,6 +89,21 @@ class TestDeletedUser(BaseDirdIntegrationTest):
 
 
 class TestAddPersonal(PersonalOnlyTestCase):
+    def test_that_a_token_with_no_user_uuid_returns_401(self):
+        mock_auth_client = MockAuthClient('localhost', self.service_port(9497, 'auth'))
+        tenant_uuid = MAIN_TENANT
+        invalid_token_uuid = str(uuid.uuid4())
+        invalid_token = MockUserToken.some_token(
+            token=invalid_token_uuid,
+            metadata={'uuid': None, 'tenant_uuid': tenant_uuid},
+        )
+        mock_auth_client.set_token(invalid_token)
+
+        result = self.post_personal_result(
+            {'firstname': 'Alice'}, token=invalid_token_uuid
+        )
+        assert_that(result, has_properties(status_code=401))
+
     def test_that_created_personal_has_an_id(self):
         alice = self.post_personal({'firstname': 'Alice'})
         bob = self.post_personal({'firstname': 'Bob'})
@@ -140,6 +158,19 @@ class TestAddPersonal(PersonalOnlyTestCase):
 
 
 class TestRemovePersonal(PersonalOnlyTestCase):
+    def test_that_a_token_with_no_user_uuid_returns_401(self):
+        mock_auth_client = MockAuthClient('localhost', self.service_port(9497, 'auth'))
+        tenant_uuid = MAIN_TENANT
+        invalid_token_uuid = str(uuid.uuid4())
+        invalid_token = MockUserToken.some_token(
+            token=invalid_token_uuid,
+            metadata={'uuid': None, 'tenant_uuid': tenant_uuid},
+        )
+        mock_auth_client.set_token(invalid_token)
+
+        result = self.delete_personal_result('unknown-id', token=invalid_token_uuid)
+        assert_that(result, has_properties(status_code=401))
+
     def test_that_removing_unknown_personal_returns_404(self):
         result = self.delete_personal_result('unknown-id', VALID_TOKEN_MAIN_TENANT)
         assert_that(result.status_code, equal_to(404))
@@ -161,6 +192,19 @@ class TestRemovePersonal(PersonalOnlyTestCase):
 
 
 class TestPurgePersonal(PersonalOnlyTestCase):
+    def test_that_a_token_with_no_user_uuid_returns_401(self):
+        mock_auth_client = MockAuthClient('localhost', self.service_port(9497, 'auth'))
+        tenant_uuid = MAIN_TENANT
+        invalid_token_uuid = str(uuid.uuid4())
+        invalid_token = MockUserToken.some_token(
+            token=invalid_token_uuid,
+            metadata={'uuid': None, 'tenant_uuid': tenant_uuid},
+        )
+        mock_auth_client.set_token(invalid_token)
+
+        result = self.purge_personal_result(token=invalid_token_uuid)
+        assert_that(result, has_properties(status_code=401))
+
     def test_that_purged_personal_are_empty(self):
         self.post_personal({'firstname': 'Alice'})
         self.post_personal({'firstname': 'Bob'})
@@ -389,6 +433,21 @@ class TestLookupPersonal(PersonalOnlyTestCase):
 
 
 class TestEditPersonal(PersonalOnlyTestCase):
+    def test_that_a_token_with_no_user_uuid_returns_401(self):
+        mock_auth_client = MockAuthClient('localhost', self.service_port(9497, 'auth'))
+        tenant_uuid = MAIN_TENANT
+        invalid_token_uuid = str(uuid.uuid4())
+        invalid_token = MockUserToken.some_token(
+            token=invalid_token_uuid,
+            metadata={'uuid': None, 'tenant_uuid': tenant_uuid},
+        )
+        mock_auth_client.set_token(invalid_token)
+
+        result = self.put_personal_result(
+            'unknown-id', {'firstname': 'new'}, token=invalid_token_uuid
+        )
+        assert_that(result, has_properties(status_code=401))
+
     def test_that_edit_inexisting_personal_contact_returns_404(self):
         body = {'firstname': 'John', 'lastname': 'Doe'}
         result = self.put_personal_result('unknown-id', body, VALID_TOKEN_MAIN_TENANT)
@@ -451,6 +510,19 @@ class TestEditInvalidPersonal(PersonalOnlyTestCase):
 
 
 class TestGetPersonal(PersonalOnlyTestCase):
+    def test_that_a_token_with_no_user_uuid_returns_401(self):
+        mock_auth_client = MockAuthClient('localhost', self.service_port(9497, 'auth'))
+        tenant_uuid = MAIN_TENANT
+        invalid_token_uuid = str(uuid.uuid4())
+        invalid_token = MockUserToken.some_token(
+            token=invalid_token_uuid,
+            metadata={'uuid': None, 'tenant_uuid': tenant_uuid},
+        )
+        mock_auth_client.set_token(invalid_token)
+
+        result = self.get_personal_result('unknown-id', token=invalid_token_uuid)
+        assert_that(result, has_properties(status_code=401))
+
     def test_that_get_inexisting_personal_contact_returns_404(self):
         result = self.get_personal_result('unknown-id', VALID_TOKEN_MAIN_TENANT)
         assert_that(result.status_code, equal_to(404))

--- a/wazo_dird/plugins/personal_service/plugin.py
+++ b/wazo_dird/plugins/personal_service/plugin.py
@@ -51,13 +51,11 @@ class _PersonalService:
         self._source_manager = source_manager
         self._controller = controller
 
-    def create_contact(self, contact_infos, token_infos):
+    def create_contact(self, contact_infos, user_uuid):
         self.validate_contact(contact_infos)
-        return self._crud.create_personal_contact(
-            token_infos['xivo_user_uuid'], contact_infos
-        )
+        return self._crud.create_personal_contact(user_uuid, contact_infos)
 
-    def create_contacts(self, contact_infos, token_infos):
+    def create_contacts(self, contact_infos, user_uuid):
         errors = []
         to_add = []
         existing_contact_uuids = set(
@@ -78,27 +76,20 @@ class _PersonalService:
             except PersonalImportError as e:
                 errors.append({'errors': [str(e)], 'line': contact_infos.line_num})
 
-        return (
-            self._crud.create_personal_contacts(token_infos['xivo_user_uuid'], to_add),
-            errors,
-        )
+        return (self._crud.create_personal_contacts(user_uuid, to_add), errors)
 
-    def get_contact(self, contact_id, token_infos):
-        return self._crud.get_personal_contact(
-            token_infos['xivo_user_uuid'], contact_id
-        )
+    def get_contact(self, contact_id, user_uuid):
+        return self._crud.get_personal_contact(user_uuid, contact_id)
 
-    def edit_contact(self, contact_id, contact_infos, token_infos):
+    def edit_contact(self, contact_id, contact_infos, user_uuid):
         self.validate_contact(contact_infos)
-        return self._crud.edit_personal_contact(
-            token_infos['xivo_user_uuid'], contact_id, contact_infos
-        )
+        return self._crud.edit_personal_contact(user_uuid, contact_id, contact_infos)
 
-    def remove_contact(self, contact_id, token_infos):
-        self._crud.delete_personal_contact(token_infos['xivo_user_uuid'], contact_id)
+    def remove_contact(self, contact_id, user_uuid):
+        self._crud.delete_personal_contact(user_uuid, contact_id)
 
-    def purge_contacts(self, token_infos):
-        self._crud.delete_all_personal_contacts(token_infos['xivo_user_uuid'])
+    def purge_contacts(self, user_uuid):
+        self._crud.delete_all_personal_contacts(user_uuid)
 
     def list_contacts(self, tenant_uuid, user_uuid):
         personal_source = self._find_personal_source(tenant_uuid)
@@ -111,8 +102,8 @@ class _PersonalService:
         formatted_contacts = source.format_contacts(contacts)
         return formatted_contacts
 
-    def list_contacts_raw(self, token_infos):
-        return self._crud.list_personal_contacts(token_infos['xivo_user_uuid'])
+    def list_contacts_raw(self, user_uuid):
+        return self._crud.list_personal_contacts(user_uuid)
 
     def _find_personal_source(self, tenant_uuid):
         source_service = self._controller.services['source']
@@ -142,5 +133,5 @@ class _PersonalService:
 
 
 class DisabledPersonalSource:
-    def list(self, _source_entry_ids, _token_infos):
+    def list(self, *args, **kwargs):
         return []


### PR DESCRIPTION
if xivo_user_uuid field is deprecated and should not be used, I chose the
metadata['uuid'] field to allow any wazo-auth user to have contacts, not only
pbx users which in most cases is the same.

If a token has no metadata['uuid'], which is not possible at the moment, a 401
error is returned instead of listing all personal contacts.