### PR TITLE
use the metadata uuid from the token instead of xivo_user_uuid

### DIFF
--- a/alembic/versions/17914dbfe398_rename_user_xivo_user_uuid.py
+++ b/alembic/versions/17914dbfe398_rename_user_xivo_user_uuid.py
@@ -1,0 +1,105 @@
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""rename user.xivo_user_uuid
+
+Revision ID: 17914dbfe398
+Revises: 07e71f4c5437
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '17914dbfe398'
+down_revision = '07e71f4c5437'
+
+
+def upgrade():
+    op.drop_constraint(
+        'dird_contact_user_uuid_fkey', 'dird_contact', type_='foreignkey'
+    )
+    op.drop_constraint(
+        'dird_favorite_user_uuid_fkey', 'dird_favorite', type_='foreignkey'
+    )
+    op.drop_constraint('dird_favorite_pkey', 'dird_favorite', type_='primary')
+
+    op.alter_column(
+        'dird_user',
+        'xivo_user_uuid',
+        existing_type=sa.String(38),
+        type_=sa.String(36),
+        new_column_name='user_uuid',
+    )
+    op.alter_column(
+        'dird_contact', 'user_uuid', existing_type=sa.String(38), type_=sa.String(36)
+    )
+    op.alter_column(
+        'dird_favorite', 'user_uuid', existing_type=sa.String(38), type_=sa.String(36)
+    )
+
+    op.create_foreign_key(
+        'dird_contact_user_uuid_fkey',
+        'dird_contact',
+        'dird_user',
+        ['user_uuid'],
+        ['user_uuid'],
+    )
+    op.create_foreign_key(
+        'dird_favorite_user_uuid_fkey',
+        'dird_favorite',
+        'dird_user',
+        ['user_uuid'],
+        ['user_uuid'],
+    )
+
+    op.create_primary_key(
+        'dird_favorite_pkey',
+        'dird_favorite',
+        ['source_uuid', 'contact_id', 'user_uuid'],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        'dird_contact_user_uuid_fkey', 'dird_contact', type_='foreignkey'
+    )
+    op.drop_constraint(
+        'dird_favorite_user_uuid_fkey', 'dird_favorite', type_='foreignkey'
+    )
+    op.drop_constraint('dird_favorite_pkey', 'dird_favorite', type_='primary')
+
+    op.alter_column(
+        'dird_user',
+        'user_uuid',
+        existing_type=sa.String(36),
+        type_=sa.String(38),
+        new_column_name='xivo_user_uuid',
+    )
+    op.alter_column(
+        'dird_favorite', 'user_uuid', existing_type=sa.String(36), type_=sa.String(38)
+    )
+    op.alter_column(
+        'dird_contact', 'user_uuid', existing_type=sa.String(36), type_=sa.String(38)
+    )
+
+    op.create_primary_key(
+        'dird_favorite_pkey',
+        'dird_favorite',
+        ['source_uuid', 'contact_id', 'user_uuid'],
+    )
+    op.create_foreign_key(
+        'dird_favorite_user_uuid_fkey',
+        'dird_favorite',
+        'dird_user',
+        ['user_uuid'],
+        ['xivo_user_uuid'],
+    )
+    op.create_foreign_key(
+        'dird_contact_user_uuid_fkey',
+        'dird_contact',
+        'dird_user',
+        ['user_uuid'],
+        ['xivo_user_uuid'],
+    )

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -143,16 +143,14 @@ class BaseDirdIntegrationTest(AutoConfiguredDirdTestCase):
         return response.json()
 
     @classmethod
-    def get_lookup_user_result(cls, term, profile, xivo_user_uuid, token=None):
+    def get_lookup_user_result(cls, term, profile, user_uuid, token=None):
         params = {'term': term}
-        url = cls.url('directories', 'lookup', profile, xivo_user_uuid)
+        url = cls.url('directories', 'lookup', profile, user_uuid)
         return cls.get(url, params=params, token=token)
 
     @classmethod
-    def lookup_user(cls, term, profile, xivo_user_uuid, token=VALID_TOKEN_MAIN_TENANT):
-        response = cls.get_lookup_user_result(
-            term, profile, xivo_user_uuid, token=token
-        )
+    def lookup_user(cls, term, profile, user_uuid, token=VALID_TOKEN_MAIN_TENANT):
+        response = cls.get_lookup_user_result(term, profile, user_uuid, token=token)
         assert_that(response.status_code, equal_to(200))
         return response.json()
 
@@ -168,14 +166,14 @@ class BaseDirdIntegrationTest(AutoConfiguredDirdTestCase):
         return response.json()
 
     @classmethod
-    def get_reverse_result(cls, exten, profile, xivo_user_uuid, token=None):
+    def get_reverse_result(cls, exten, profile, user_uuid, token=None):
         params = {'exten': exten}
-        url = cls.url('directories', 'reverse', profile, xivo_user_uuid)
+        url = cls.url('directories', 'reverse', profile, user_uuid)
         return cls.get(url, params=params, token=token)
 
     @classmethod
-    def reverse(cls, exten, profile, xivo_user_uuid, token=VALID_TOKEN_MAIN_TENANT):
-        response = cls.get_reverse_result(exten, profile, xivo_user_uuid, token=token)
+    def reverse(cls, exten, profile, user_uuid, token=VALID_TOKEN_MAIN_TENANT):
+        response = cls.get_reverse_result(exten, profile, user_uuid, token=token)
         assert_that(response.status_code, equal_to(200))
         return response.json()
 
@@ -416,28 +414,28 @@ class BaseDirdIntegrationTest(AutoConfiguredDirdTestCase):
         return response.json()
 
     @classmethod
-    def get_menu_cisco_result(cls, profile, xivo_user_uuid, proxy=None, token=None):
-        url = cls.url('directories', 'menu', profile, xivo_user_uuid, 'cisco')
+    def get_menu_cisco_result(cls, profile, user_uuid, proxy=None, token=None):
+        url = cls.url('directories', 'menu', profile, user_uuid, 'cisco')
         return cls.get(url, headers={'X-Auth-Token': token, 'Proxy-URL': proxy})
 
     @classmethod
     def get_menu_cisco(
-        cls, profile, xivo_user_uuid, proxy=None, token=VALID_TOKEN_MAIN_TENANT
+        cls, profile, user_uuid, proxy=None, token=VALID_TOKEN_MAIN_TENANT
     ):
-        response = cls.get_menu_cisco_result(profile, xivo_user_uuid, proxy, token)
+        response = cls.get_menu_cisco_result(profile, user_uuid, proxy, token)
         assert_that(response.status_code, equal_to(200))
         return response.text
 
     @classmethod
-    def get_input_cisco_result(cls, profile, xivo_user_uuid, proxy=None, token=None):
-        url = cls.url('directories', 'input', profile, xivo_user_uuid, 'cisco')
+    def get_input_cisco_result(cls, profile, user_uuid, proxy=None, token=None):
+        url = cls.url('directories', 'input', profile, user_uuid, 'cisco')
         return cls.get(url, headers={'X-Auth-Token': token, 'Proxy-URL': proxy})
 
     @classmethod
     def get_input_cisco(
-        cls, profile, xivo_user_uuid, proxy=None, token=VALID_TOKEN_MAIN_TENANT
+        cls, profile, user_uuid, proxy=None, token=VALID_TOKEN_MAIN_TENANT
     ):
-        response = cls.get_input_cisco_result(profile, xivo_user_uuid, proxy, token)
+        response = cls.get_input_cisco_result(profile, user_uuid, proxy, token)
         assert_that(response.status_code, equal_to(200))
         return response.text
 
@@ -445,14 +443,14 @@ class BaseDirdIntegrationTest(AutoConfiguredDirdTestCase):
     def get_lookup_cisco_result(
         cls,
         profile,
-        xivo_user_uuid,
+        user_uuid,
         proxy=None,
         term=None,
         token=None,
         limit=None,
         offset=None,
     ):
-        url = cls.url('directories', 'lookup', profile, xivo_user_uuid, 'cisco')
+        url = cls.url('directories', 'lookup', profile, user_uuid, 'cisco')
         params = {'term': term, 'limit': limit, 'offset': offset}
         return cls.get(
             url, params=params, headers={'X-Auth-Token': token, 'Proxy-URL': proxy}
@@ -462,7 +460,7 @@ class BaseDirdIntegrationTest(AutoConfiguredDirdTestCase):
     def get_lookup_cisco(
         cls,
         profile,
-        xivo_user_uuid,
+        user_uuid,
         term,
         proxy=None,
         token=VALID_TOKEN_MAIN_TENANT,
@@ -470,72 +468,72 @@ class BaseDirdIntegrationTest(AutoConfiguredDirdTestCase):
         offset=None,
     ):
         response = cls.get_lookup_cisco_result(
-            profile, xivo_user_uuid, proxy, term, token, limit, offset
+            profile, user_uuid, proxy, term, token, limit, offset
         )
         assert_that(response.status_code, equal_to(200))
         return response.text
 
     @classmethod
-    def get_input_aastra_result(cls, profile, xivo_user_uuid, proxy=None, token=None):
-        url = cls.url('directories', 'input', profile, xivo_user_uuid, 'aastra')
+    def get_input_aastra_result(cls, profile, user_uuid, proxy=None, token=None):
+        url = cls.url('directories', 'input', profile, user_uuid, 'aastra')
         return cls.get(url, headers={'X-Auth-Token': token, 'Proxy-URL': proxy})
 
     @classmethod
     def get_lookup_aastra_result(
         cls,
         profile,
-        xivo_user_uuid,
+        user_uuid,
         proxy=None,
         term=None,
         token=None,
         limit=None,
         offset=None,
     ):
-        url = cls.url('directories', 'lookup', profile, xivo_user_uuid, 'aastra')
+        url = cls.url('directories', 'lookup', profile, user_uuid, 'aastra')
         params = {'term': term, 'limit': limit, 'offset': offset}
         return cls.get(
             url, params=params, headers={'X-Auth-Token': token, 'Proxy-URL': proxy}
         )
 
     @classmethod
-    def get_input_polycom_result(cls, profile, xivo_user_uuid, proxy=None, token=None):
-        url = cls.url('directories', 'input', profile, xivo_user_uuid, 'polycom')
+    def get_input_polycom_result(cls, profile, user_uuid, proxy=None, token=None):
+        url = cls.url('directories', 'input', profile, user_uuid, 'polycom')
         return cls.get(url, headers={'X-Auth-Token': token, 'Proxy-URL': proxy})
 
     @classmethod
     def get_lookup_polycom_result(
         cls,
         profile,
-        xivo_user_uuid,
+        user_uuid,
         proxy=None,
         term=None,
         token=None,
         limit=None,
         offset=None,
     ):
-        url = cls.url('directories', 'lookup', profile, xivo_user_uuid, 'polycom')
+        url = cls.url('directories', 'lookup', profile, user_uuid, 'polycom')
         params = {'term': term, 'limit': limit, 'offset': offset}
         return cls.get(
             url, params=params, headers={'X-Auth-Token': token, 'Proxy-URL': proxy}
         )
 
     @classmethod
-    def get_input_snom_result(cls, profile, xivo_user_uuid, proxy=None, token=None):
-        url = cls.url('directories', 'input', profile, xivo_user_uuid, 'snom')
+    def get_input_snom_result(cls, profile, user_uuid, proxy=None, token=None):
+        url = cls.url('directories', 'input', profile, user_uuid, 'snom')
         return cls.get(url, headers={'X-Auth-Token': token, 'Proxy-URL': proxy})
 
     @classmethod
     def get_lookup_snom_result(
         cls,
         profile,
-        xivo_user_uuid,
+        user_uuid,
         proxy=None,
         term=None,
         token=None,
         limit=None,
         offset=None,
     ):
-        url = cls.url('directories', 'lookup', profile, xivo_user_uuid, 'snom')
+        url = cls.url('directories', 'lookup', profile, user_uuid, 'snom')
         params = {'term': term, 'limit': limit, 'offset': offset}
         return cls.get(
             url, params=params, headers={'X-Auth-Token': token, 'Proxy-URL': proxy}
@@ -545,14 +543,14 @@ class BaseDirdIntegrationTest(AutoConfiguredDirdTestCase):
     def get_lookup_thomson_result(
         cls,
         profile,
-        xivo_user_uuid,
+        user_uuid,
         proxy=None,
         term=None,
         token=None,
         limit=None,
         offset=None,
     ):
-        url = cls.url('directories', 'lookup', profile, xivo_user_uuid, 'thomson')
+        url = cls.url('directories', 'lookup', profile, user_uuid, 'thomson')
         params = {'term': term, 'limit': limit, 'offset': offset}
         return cls.get(
             url, params=params, headers={'X-Auth-Token': token, 'Proxy-URL': proxy}
@@ -562,14 +560,14 @@ class BaseDirdIntegrationTest(AutoConfiguredDirdTestCase):
     def get_lookup_yealink_result(
         cls,
         profile,
-        xivo_user_uuid,
+        user_uuid,
         proxy=None,
         term=None,
         token=None,
         limit=None,
         offset=None,
     ):
-        url = cls.url('directories', 'lookup', profile, xivo_user_uuid, 'yealink')
+        url = cls.url('directories', 'lookup', profile, user_uuid, 'yealink')
         params = {'term': term, 'limit': limit, 'offset': offset}
         return cls.get(
             url, params=params, headers={'X-Auth-Token': token, 'Proxy-URL': proxy}
@@ -579,14 +577,14 @@ class BaseDirdIntegrationTest(AutoConfiguredDirdTestCase):
     def get_lookup_gigaset_result(
         cls,
         profile,
-        xivo_user_uuid,
+        user_uuid,
         proxy=None,
         term=None,
         token=None,
         limit=None,
         offset=None,
     ):
-        url = cls.url('directories', 'lookup', profile, xivo_user_uuid, 'gigaset')
+        url = cls.url('directories', 'lookup', profile, user_uuid, 'gigaset')
         params = {'term': term, 'limit': limit, 'offset': offset}
         return cls.get(
             url, params=params, headers={'X-Auth-Token': token, 'Proxy-URL': proxy}
@@ -596,14 +594,14 @@ class BaseDirdIntegrationTest(AutoConfiguredDirdTestCase):
     def get_lookup_htek_result(
         cls,
         profile,
-        xivo_user_uuid,
+        user_uuid,
         proxy=None,
         term=None,
         token=None,
         limit=None,
         offset=None,
     ):
-        url = cls.url('directories', 'lookup', profile, xivo_user_uuid, 'htek')
+        url = cls.url('directories', 'lookup', profile, user_uuid, 'htek')
         params = {'term': term, 'limit': limit, 'offset': offset}
         return cls.get(
             url, params=params, headers={'X-Auth-Token': token, 'Proxy-URL': proxy}

--- a/integration_tests/suite/test_core_functionality.py
+++ b/integration_tests/suite/test_core_functionality.py
@@ -143,7 +143,7 @@ class TestReverse(BaseMultipleSourceLauncher):
 
         assert_that(result, equal_to(expected))
 
-    def test_reverse_with_xivo_user_uuid(self):
+    def test_reverse_with_user_uuid(self):
         result = self.get_reverse_result(
             '1111', 'default', VALID_UUID, VALID_TOKEN_MAIN_TENANT
         )

--- a/integration_tests/suite/test_database.py
+++ b/integration_tests/suite/test_database.py
@@ -52,13 +52,13 @@ def with_user_uuid(f):
     @functools.wraps(f)
     def wrapped(self, *args, **kwargs):
         user_uuid = new_uuid()
-        user = database.User(xivo_user_uuid=user_uuid)
+        user = database.User(user_uuid=user_uuid)
         with closing(Session()) as session:
             session.add(user)
             session.commit()
             result = f(self, user_uuid, *args, **kwargs)
             session.query(database.User).filter(
-                database.User.xivo_user_uuid == user_uuid
+                database.User.user_uuid == user_uuid
             ).delete()
             session.commit()
         return result
@@ -1124,8 +1124,8 @@ class TestFavoriteCrud(_BaseTest):
     def _user_exists(self, user_uuid):
         with closing(Session()) as session:
             user_uuid = (
-                session.query(database.User.xivo_user_uuid)
-                .filter(database.User.xivo_user_uuid == user_uuid)
+                session.query(database.User.user_uuid)
+                .filter(database.User.user_uuid == user_uuid)
                 .scalar()
             )
 
@@ -1139,7 +1139,7 @@ class TestFavoriteCrud(_BaseTest):
                 .join(database.User)
                 .filter(
                     and_(
-                        database.User.xivo_user_uuid == user_uuid,
+                        database.User.user_uuid == user_uuid,
                         database.Source.name == source_name,
                         database.Favorite.contact_id == contact_id,
                     )

--- a/integration_tests/suite/test_google.py
+++ b/integration_tests/suite/test_google.py
@@ -185,7 +185,7 @@ class TestGooglePlugin(BaseDirdIntegrationTest):
     @fixtures.google_result(GOOGLE_CONTACT_LIST)
     def test_plugin_reverse(self, google_api):
         response = self.client.directories.reverse(
-            exten='+15555551234', profile='default', xivo_user_uuid='uuid-tenant-master'
+            exten='+15555551234', profile='default', user_uuid='uuid-tenant-master'
         )
 
         assert_that(response, has_entries(display='Mario Bros'))

--- a/integration_tests/suite/test_office365_backend.py
+++ b/integration_tests/suite/test_office365_backend.py
@@ -38,8 +38,8 @@ class BaseOffice365TestCase(DirdAssetRunningTestCase):
         "token_expiration": 42,
     }
 
-    LOOKUP_ARGS = {'xivo_user_uuid': 'a-xivo-uuid', 'token': 'a-token'}
-    FAVORITE_ARGS = {'xivo_user_uuid': 'a-xivo-uuid', 'token': 'a-token'}
+    LOOKUP_ARGS = {'user_uuid': 'a-xivo-uuid', 'token': 'a-token'}
+    FAVORITE_ARGS = {'user_uuid': 'a-xivo-uuid', 'token': 'a-token'}
 
     WARIO = {'givenName': 'Wario', 'surname': 'Bros', 'mobilePhone': ''}
 

--- a/integration_tests/suite/test_personal.py
+++ b/integration_tests/suite/test_personal.py
@@ -398,12 +398,12 @@ class TestLookupPersonal(PersonalOnlyTestCase):
             ),
         )
 
-    def test_reverse_lookup_with_xivo_user_uuid(self):
+    def test_reverse_lookup_with_user_uuid(self):
         result = self.reverse('123456', 'default', VALID_UUID)
 
         assert_that(result['display'], equal_to('Elice Wowo'))
 
-    def test_reverse_lookup_with_invalid_xivo_user_uuid(self):
+    def test_reverse_lookup_with_invalid_user_uuid(self):
         result = self.reverse('123456', 'default', 'invalid_uuid')
 
         assert_that(result['display'], is_(none()))

--- a/wazo_dird/database/models.py
+++ b/wazo_dird/database/models.py
@@ -24,7 +24,7 @@ class Contact(Base):
         String(38), server_default=text('uuid_generate_v4()'), primary_key=True
     )
     user_uuid = Column(
-        String(38), ForeignKey('dird_user.xivo_user_uuid', ondelete='CASCADE')
+        String(UUID_LENGTH), ForeignKey('dird_user.user_uuid', ondelete='CASCADE')
     )
     phonebook_id = Column(
         Integer(), ForeignKey('dird_phonebook.id', ondelete='CASCADE')
@@ -90,8 +90,8 @@ class Favorite(Base):
     )
     contact_id = Column(Text(), primary_key=True)
     user_uuid = Column(
-        String(38),
-        ForeignKey('dird_user.xivo_user_uuid', ondelete='CASCADE'),
+        String(UUID_LENGTH),
+        ForeignKey('dird_user.user_uuid', ondelete='CASCADE'),
         primary_key=True,
     )
 
@@ -240,4 +240,4 @@ class User(Base):
 
     __tablename__ = 'dird_user'
 
-    xivo_user_uuid = Column(String(38), primary_key=True)
+    user_uuid = Column(String(UUID_LENGTH), primary_key=True)

--- a/wazo_dird/database/queries/base.py
+++ b/wazo_dird/database/queries/base.py
@@ -16,8 +16,8 @@ from .. import ContactFields
 sqlalchemy_helper.handle_db_restart()
 
 
-def delete_user(session, xivo_user_uuid):
-    session.query(User).filter(User.xivo_user_uuid == xivo_user_uuid).delete()
+def delete_user(session, user_uuid):
+    session.query(User).filter(User.xivo_user_uuid == user_uuid).delete()
 
 
 def extract_constraint_name(error):
@@ -83,10 +83,10 @@ class BaseDAO:
         except exc.IntegrityError:
             s.rollback()
 
-    def _get_dird_user(self, session, xivo_user_uuid):
-        user = session.query(User).filter(User.xivo_user_uuid == xivo_user_uuid).first()
+    def _get_dird_user(self, session, user_uuid):
+        user = session.query(User).filter(User.xivo_user_uuid == user_uuid).first()
         if not user:
-            user = User(xivo_user_uuid=xivo_user_uuid)
+            user = User(xivo_user_uuid=user_uuid)
             session.add(user)
             session.flush()
 

--- a/wazo_dird/database/queries/base.py
+++ b/wazo_dird/database/queries/base.py
@@ -17,7 +17,7 @@ sqlalchemy_helper.handle_db_restart()
 
 
 def delete_user(session, user_uuid):
-    session.query(User).filter(User.xivo_user_uuid == user_uuid).delete()
+    session.query(User).filter(User.user_uuid == user_uuid).delete()
 
 
 def extract_constraint_name(error):
@@ -84,9 +84,9 @@ class BaseDAO:
             s.rollback()
 
     def _get_dird_user(self, session, user_uuid):
-        user = session.query(User).filter(User.xivo_user_uuid == user_uuid).first()
+        user = session.query(User).filter(User.user_uuid == user_uuid).first()
         if not user:
-            user = User(xivo_user_uuid=user_uuid)
+            user = User(user_uuid=user_uuid)
             session.add(user)
             session.flush()
 

--- a/wazo_dird/database/queries/favorite.py
+++ b/wazo_dird/database/queries/favorite.py
@@ -10,21 +10,19 @@ from .base import BaseDAO
 
 
 class FavoriteCRUD(BaseDAO):
-    def create(self, xivo_user_uuid, backend, source_name, contact_id):
+    def create(self, user_uuid, backend, source_name, contact_id):
         with self.new_session() as s:
-            user = self._get_dird_user(s, xivo_user_uuid)
+            user = self._get_dird_user(s, user_uuid)
             source = self._get_source(s, backend, source_name)
             favorite = Favorite(
-                source_uuid=source.uuid,
-                contact_id=contact_id,
-                user_uuid=user.xivo_user_uuid,
+                source_uuid=source.uuid, contact_id=contact_id, user_uuid=user.xivo_user_uuid
             )
             s.add(favorite)
             self.flush_or_raise(s, DuplicatedFavoriteException)
             make_transient(favorite)
             return favorite
 
-    def delete(self, xivo_user_uuid, source_name, contact_id):
+    def delete(self, user_uuid, source_name, contact_id):
         with self.new_session() as s:
             matching_source_uuids = (
                 s.query(Source.uuid).filter(Source.name == source_name).all()
@@ -34,7 +32,7 @@ class FavoriteCRUD(BaseDAO):
 
             filter_ = and_(
                 Favorite.contact_id == contact_id,
-                Favorite.user_uuid == xivo_user_uuid,
+                Favorite.user_uuid == user_uuid,
                 Favorite.source_uuid.in_(matching_source_uuids),
             )
             deleted = (
@@ -46,12 +44,12 @@ class FavoriteCRUD(BaseDAO):
         if not deleted:
             raise NoSuchFavorite((source_name, contact_id))
 
-    def get(self, xivo_user_uuid):
+    def get(self, user_uuid):
         with self.new_session() as s:
             favorites = (
                 s.query(Favorite.contact_id, Source.name)
                 .join(Source)
-                .filter(Favorite.user_uuid == xivo_user_uuid)
+                .filter(Favorite.user_uuid == user_uuid)
             )
             return [(f.name, f.contact_id) for f in favorites.all()]
 

--- a/wazo_dird/database/queries/favorite.py
+++ b/wazo_dird/database/queries/favorite.py
@@ -15,7 +15,7 @@ class FavoriteCRUD(BaseDAO):
             user = self._get_dird_user(s, user_uuid)
             source = self._get_source(s, backend, source_name)
             favorite = Favorite(
-                source_uuid=source.uuid, contact_id=contact_id, user_uuid=user.xivo_user_uuid
+                source_uuid=source.uuid, contact_id=contact_id, user_uuid=user.user_uuid
             )
             s.add(favorite)
             self.flush_or_raise(s, DuplicatedFavoriteException)

--- a/wazo_dird/database/queries/personal.py
+++ b/wazo_dird/database/queries/personal.py
@@ -58,9 +58,7 @@ class PersonalContactSearchEngine(BaseDAO):
         if not uuids:
             return False
 
-        return and_(
-            User.xivo_user_uuid == user_uuid, ContactFields.contact_uuid.in_(uuids)
-        )
+        return and_(User.user_uuid == user_uuid, ContactFields.contact_uuid.in_(uuids))
 
     def _new_search_filter(self, user_uuid, term, columns):
         if not columns:
@@ -68,7 +66,7 @@ class PersonalContactSearchEngine(BaseDAO):
 
         pattern = '%{}%'.format(unidecode(term))
         return and_(
-            User.xivo_user_uuid == user_uuid,
+            User.user_uuid == user_uuid,
             unaccent(ContactFields.value).ilike(pattern),
             ContactFields.name.in_(columns),
         )
@@ -78,13 +76,13 @@ class PersonalContactSearchEngine(BaseDAO):
             return False
 
         return and_(
-            User.xivo_user_uuid == user_uuid,
+            User.user_uuid == user_uuid,
             unaccent(ContactFields.value) == unidecode(term),
             ContactFields.name.in_(columns),
         )
 
     def _new_user_contacts_filter(self, user_uuid):
-        return User.xivo_user_uuid == user_uuid
+        return User.user_uuid == user_uuid
 
 
 class PersonalContactCRUD(BaseDAO):
@@ -125,7 +123,7 @@ class PersonalContactCRUD(BaseDAO):
 
         for hash_ in to_add:
             contact_info = hash_and_contact[hash_]
-            contact_args = {'user_uuid': user.xivo_user_uuid, 'hash': hash_}
+            contact_args = {'user_uuid': user.user_uuid, 'hash': hash_}
             contact_uuid = contact_info.get('id')
             if contact_uuid:
                 contact_args['uuid'] = contact_uuid
@@ -167,8 +165,7 @@ class PersonalContactCRUD(BaseDAO):
     def get_personal_contact(self, user_uuid, contact_uuid):
         with self.new_session() as s:
             filter_ = and_(
-                User.xivo_user_uuid == user_uuid,
-                ContactFields.contact_uuid == contact_uuid,
+                User.user_uuid == user_uuid, ContactFields.contact_uuid == contact_uuid
             )
             contact_uuids = (
                 s.query(distinct(ContactFields.contact_uuid))
@@ -184,7 +181,7 @@ class PersonalContactCRUD(BaseDAO):
 
     def delete_all_personal_contacts(self, user_uuid):
         with self.new_session() as s:
-            filter_ = User.xivo_user_uuid == user_uuid
+            filter_ = User.user_uuid == user_uuid
             return self._delete_personal_contacts_with_filter(s, filter_)
 
     def delete_personal_contact(self, user_uuid, contact_uuid):
@@ -193,7 +190,7 @@ class PersonalContactCRUD(BaseDAO):
 
     def _delete_personal_contact(self, session, user_uuid, contact_uuid):
         filter_ = and_(
-            User.xivo_user_uuid == user_uuid, ContactFields.contact_uuid == contact_uuid
+            User.user_uuid == user_uuid, ContactFields.contact_uuid == contact_uuid
         )
         nb_deleted = self._delete_personal_contacts_with_filter(session, filter_)
         if nb_deleted == 0:

--- a/wazo_dird/plugins/aastra/api.yml
+++ b/wazo_dird/plugins/aastra/api.yml
@@ -1,9 +1,9 @@
 paths:
-  /directories/input/{profile}/{xivo_user_uuid}/aastra:
+  /directories/input/{profile}/{user_uuid}/aastra:
     get:
       summary: Given informations about how make request lookup for Aastra Phones
       description: |
-        **Required ACL:** `dird.directories.input.{profile}.{xivo_user_uuid}.read`
+        **Required ACL:** `dird.directories.input.{profile}.{user_uuid}.read`
 
         The `input` query will return a XML to give informations about how make request
         lookup for Aastra Phones.
@@ -22,13 +22,13 @@ paths:
           $ref: '#/responses/AnotherServiceUnavailable'
       parameters:
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/ProxyUrl'
-  /directories/lookup/{profile}/{xivo_user_uuid}/aastra:
+  /directories/lookup/{profile}/{user_uuid}/aastra:
     get:
       summary: Search for contacts with Aastra Phones
       description: |
-        **Required ACL:** `dird.directories.lookup.{profile}.{xivo_user_uuid}.read`
+        **Required ACL:** `dird.directories.lookup.{profile}.{user_uuid}.read`
 
         The `lookup` query will return a list of result matching the searched term
         formated for Aastra Phones. The result will be retrieved from all configured
@@ -55,7 +55,7 @@ paths:
           $ref: '#/responses/AnotherServiceUnavailable'
       parameters:
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/Term'
       - $ref: '#/parameters/Limit16'
       - $ref: '#/parameters/Offset'

--- a/wazo_dird/plugins/aastra/plugin.py
+++ b/wazo_dird/plugins/aastra/plugin.py
@@ -14,8 +14,8 @@ MAX_ITEM_PER_PAGE = 16
 
 class AastraViewPlugin(BaseViewPlugin):
 
-    aastra_input = '/directories/input/<profile>/<xivo_user_uuid>/aastra'
-    aastra_lookup = '/directories/lookup/<profile>/<xivo_user_uuid>/aastra'
+    aastra_input = '/directories/input/<profile>/<user_uuid>/aastra'
+    aastra_lookup = '/directories/lookup/<profile>/<user_uuid>/aastra'
 
     def load(self, dependencies):
         api = dependencies['api']

--- a/wazo_dird/plugins/api/api.yml
+++ b/wazo_dird/plugins/api/api.yml
@@ -174,12 +174,11 @@ parameters:
     type: string
     description: A search term to look for
     required: true
-  XivoUserUUID:
-    name: xivo_user_uuid
+  UserUUID:
+    name: user_uuid
     in: path
     type: string
-    description: The XiVO user uuid on which the result is associated (e.g. used to
-      search in personal contacts)
+    description: The user UUID of the user doing that query
     required: true
 definitions:
   Error:

--- a/wazo_dird/plugins/cisco/api.yml
+++ b/wazo_dird/plugins/cisco/api.yml
@@ -1,9 +1,9 @@
 paths:
-  /directories/menu/{profile}/{xivo_user_uuid}/cisco:
+  /directories/menu/{profile}/{user_uuid}/cisco:
     get:
       summary: Extends the directories menu for Cisco Unified IP Phones
       description: |
-        **Required ACL:** `dird.directories.menu.{profile}.{xivo_user_uuid}.read`
+        **Required ACL:** `dird.directories.menu.{profile}.{user_uuid}.read`
 
         The `menu` query will return a XML to extend the directories menu for Cisco
         Unified IP Phones.
@@ -22,15 +22,15 @@ paths:
           $ref: '#/responses/AnotherServiceUnavailable'
       parameters:
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/ProxyUrl'
       - $ref: '#/parameters/AcceptLanguage'
-  /directories/input/{profile}/{xivo_user_uuid}/cisco:
+  /directories/input/{profile}/{user_uuid}/cisco:
     get:
       summary: Given informations about how make request lookup for Cisco Unified
         IP Phones
       description: |
-        **Required ACL:** `dird.directories.input.{profile}.{xivo_user_uuid}.read`
+        **Required ACL:** `dird.directories.input.{profile}.{user_uuid}.read`
 
         The `input` query will return a XML to give informations about how make request
         lookup for Cisco Unified IP Phones.
@@ -49,14 +49,14 @@ paths:
           $ref: '#/responses/AnotherServiceUnavailable'
       parameters:
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/ProxyUrl'
       - $ref: '#/parameters/AcceptLanguage'
-  /directories/lookup/{profile}/{xivo_user_uuid}/cisco:
+  /directories/lookup/{profile}/{user_uuid}/cisco:
     get:
       summary: Search for contacts with Cisco Unified IP Phones
       description: |
-        **Required ACL:** `dird.directories.lookup.{profile}.{xivo_user_uuid}.read`
+        **Required ACL:** `dird.directories.lookup.{profile}.{user_uuid}.read`
 
         The `lookup` query will return a list of result matching the searched term
         formated for Cisco Unified IP Phones. The result will be retrieved from all
@@ -83,7 +83,7 @@ paths:
           $ref: '#/responses/AnotherServiceUnavailable'
       parameters:
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/Term'
       - $ref: '#/parameters/Limit16'
       - $ref: '#/parameters/Offset'

--- a/wazo_dird/plugins/cisco/plugin.py
+++ b/wazo_dird/plugins/cisco/plugin.py
@@ -15,9 +15,9 @@ MAX_ITEM_PER_PAGE = 16
 
 class CiscoViewPlugin(BaseViewPlugin):
 
-    cisco_menu = '/directories/menu/<profile>/<xivo_user_uuid>/cisco'
-    cisco_input = '/directories/input/<profile>/<xivo_user_uuid>/cisco'
-    cisco_lookup = '/directories/lookup/<profile>/<xivo_user_uuid>/cisco'
+    cisco_menu = '/directories/menu/<profile>/<user_uuid>/cisco'
+    cisco_input = '/directories/input/<profile>/<user_uuid>/cisco'
+    cisco_lookup = '/directories/lookup/<profile>/<user_uuid>/cisco'
 
     def load(self, dependencies):
         api = dependencies['api']

--- a/wazo_dird/plugins/default_json/api.yml
+++ b/wazo_dird/plugins/default_json/api.yml
@@ -177,10 +177,3 @@ paths:
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/Profile'
-parameters:
-  UserUUID:
-    name: user_uuid
-    in: path
-    type: string
-    description: The user UUID of the user doing that query
-    required: true

--- a/wazo_dird/plugins/default_json/api.yml
+++ b/wazo_dird/plugins/default_json/api.yml
@@ -29,10 +29,10 @@ paths:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/Profile'
       - $ref: '#/parameters/Term'
-  /directories/lookup/{profile}/{xivo_user_uuid}:
+  /directories/lookup/{profile}/{user_uuid}:
     get:
       summary: Search for contacts for a particular user
-      description: '**Required ACL:** `dird.directories.lookup.{profile}.{xivo_user_uuid}.read`
+      description: '**Required ACL:** `dird.directories.lookup.{profile}.{user_uuid}.read`
 
 
         The `lookup` query will return a list of result matching the searched term.
@@ -58,12 +58,12 @@ paths:
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/Term'
-  /directories/reverse/{profile}/{xivo_user_uuid}:
+  /directories/reverse/{profile}/{user_uuid}:
     get:
       summary: Search for contact by number
-      description: '**Required ACL:** `dird.directories.reverse.{profile}.{xivo_user_uuid}.read`
+      description: '**Required ACL:** `dird.directories.reverse.{profile}.{user_uuid}.read`
 
 
         The `reverse` query will return a contact matching the searched exten. The
@@ -86,7 +86,7 @@ paths:
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/Exten'
   /directories/favorites/{profile}:
     get:
@@ -177,3 +177,10 @@ paths:
       parameters:
       - $ref: '#/parameters/tenantuuid'
       - $ref: '#/parameters/Profile'
+parameters:
+  UserUUID:
+    name: user_uuid
+    in: path
+    type: string
+    description: The user UUID of the user doing that query
+    required: true

--- a/wazo_dird/plugins/default_json/http.py
+++ b/wazo_dird/plugins/default_json/http.py
@@ -38,7 +38,7 @@ def _error(code, msg):
 
 
 class DisabledFavoriteService:
-    def favorite_ids(self, profile, xivo_user_uuid):
+    def favorite_ids(self, profile, user_uuid):
         return []
 
 
@@ -100,12 +100,11 @@ class LookupByUUID(AuthResource, DisplayAwareResource):
 
     @required_acl('dird.directories.lookup.{profile}.{xivo_user_uuid}.read')
     def get(self, profile, xivo_user_uuid):
+        user_uuid = xivo_user_uuid
         args = parser.parse_args()
         term = args['term']
 
-        logger.info(
-            'Lookup %s for user %s with profile %s', term, xivo_user_uuid, profile
-        )
+        logger.info('Lookup %s for user %s with profile %s', term, user_uuid, profile)
 
         tenant_uuid = Tenant.autodetect().uuid
         try:
@@ -117,10 +116,10 @@ class LookupByUUID(AuthResource, DisplayAwareResource):
         token = request.headers['X-Auth-Token']
 
         raw_results = self.lookup_service.lookup(
-            profile_config, tenant_uuid, term, xivo_user_uuid, token=token
+            profile_config, tenant_uuid, term, user_uuid, token=token
         )
         favorites = self.favorite_service.favorite_ids(
-            profile_config, xivo_user_uuid
+            profile_config, user_uuid
         ).by_name
         formatter = _ResultFormatter(display)
         response = formatter.format_results(raw_results, favorites)
@@ -147,6 +146,7 @@ class Reverse(LegacyAuthResource):
 
     @required_acl('dird.directories.reverse.{profile}.{xivo_user_uuid}.read')
     def get(self, profile, xivo_user_uuid):
+        user_uuid = xivo_user_uuid
         token = request.headers['X-Auth-Token']
         args = parser_reverse.parse_args()
         exten = args['exten']
@@ -160,7 +160,7 @@ class Reverse(LegacyAuthResource):
         logger.info('Reverse for %s with profile %s', exten, profile)
 
         raw_result = self.reverse_service.reverse(
-            profile_config, exten, profile, xivo_user_uuid=xivo_user_uuid, token=token
+            profile_config, exten, profile, user_uuid=user_uuid, token=token
         )
 
         response = {'display': None, 'exten': exten, 'fields': {}, 'source': None}

--- a/wazo_dird/plugins/default_json/http.py
+++ b/wazo_dird/plugins/default_json/http.py
@@ -98,9 +98,8 @@ class LookupByUUID(AuthResource, DisplayAwareResource):
         self.profile_service = profile_service
         self.auth_client = auth_client
 
-    @required_acl('dird.directories.lookup.{profile}.{xivo_user_uuid}.read')
-    def get(self, profile, xivo_user_uuid):
-        user_uuid = xivo_user_uuid
+    @required_acl('dird.directories.lookup.{profile}.{user_uuid}.read')
+    def get(self, profile, user_uuid):
         args = parser.parse_args()
         term = args['term']
 
@@ -144,9 +143,8 @@ class Reverse(LegacyAuthResource):
         self.reverse_service = reverse_service
         self.profile_service = profile_service
 
-    @required_acl('dird.directories.reverse.{profile}.{xivo_user_uuid}.read')
-    def get(self, profile, xivo_user_uuid):
-        user_uuid = xivo_user_uuid
+    @required_acl('dird.directories.reverse.{profile}.{user_uuid}.read')
+    def get(self, profile, user_uuid):
         token = request.headers['X-Auth-Token']
         args = parser_reverse.parse_args()
         exten = args['exten']

--- a/wazo_dird/plugins/default_json/plugin.py
+++ b/wazo_dird/plugins/default_json/plugin.py
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 class JsonViewPlugin(BaseViewPlugin):
 
     lookup_url = '/directories/lookup/<profile>'
-    uuid_lookup_url = '/directories/lookup/<profile>/<xivo_user_uuid>'
-    reverse_url = '/directories/reverse/<profile>/<xivo_user_uuid>'
+    uuid_lookup_url = '/directories/lookup/<profile>/<user_uuid>'
+    reverse_url = '/directories/reverse/<profile>/<user_uuid>'
     favorites_read_url = '/directories/favorites/<profile>'
     favorites_write_url = '/directories/favorites/<directory>/<contact>'
     personal_url = '/directories/personal/<profile>'

--- a/wazo_dird/plugins/gigaset/api.yml
+++ b/wazo_dird/plugins/gigaset/api.yml
@@ -1,9 +1,9 @@
 paths:
-  /directories/lookup/{profile}/{xivo_user_uuid}/gigaset:
+  /directories/lookup/{profile}/{user_uuid}/gigaset:
     get:
       summary: Search for contacts with Gigaset Phones
       description: |
-        **Required ACL:** `dird.directories.lookup.{profile}.{xivo_user_uuid}.read`
+        **Required ACL:** `dird.directories.lookup.{profile}.{user_uuid}.read`
 
         The `lookup` query will return a list of result matching the searched term
         formated for Gigaset Phones. The result will be retrieved from all configured
@@ -30,7 +30,7 @@ paths:
           $ref: '#/responses/AnotherServiceUnavailable'
       parameters:
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/Term'
       - $ref: '#/parameters/Limit'
       - $ref: '#/parameters/Offset'

--- a/wazo_dird/plugins/gigaset/plugin.py
+++ b/wazo_dird/plugins/gigaset/plugin.py
@@ -12,7 +12,7 @@ CONTENT_TYPE = 'text/xml'
 
 class GigasetViewPlugin(BaseViewPlugin):
 
-    gigaset_lookup = '/directories/lookup/<profile>/<xivo_user_uuid>/gigaset'
+    gigaset_lookup = '/directories/lookup/<profile>/<user_uuid>/gigaset'
 
     def load(self, dependencies):
         api = dependencies['api']

--- a/wazo_dird/plugins/google_backend/plugin.py
+++ b/wazo_dird/plugins/google_backend/plugin.py
@@ -129,12 +129,12 @@ class GooglePlugin(BaseSourcePlugin):
 
         return False
 
-    def _get_google_token(self, xivo_user_uuid, token=None, **ignored):
+    def _get_google_token(self, user_uuid, token=None, **ignored):
         if not token:
             logger.debug('Unable to search through Google without a token.')
             raise GoogleTokenNotFoundException()
 
-        return services.get_google_access_token(xivo_user_uuid, token, **self.auth)
+        return services.get_google_access_token(user_uuid, token, **self.auth)
 
     def _search_match_predicate(self, contact, term):
         for field in self._searched_columns:

--- a/wazo_dird/plugins/htek/api.yml
+++ b/wazo_dird/plugins/htek/api.yml
@@ -1,9 +1,9 @@
 paths:
-  /directories/lookup/{profile}/{xivo_user_uuid}/htek:
+  /directories/lookup/{profile}/{user_uuid}/htek:
     get:
       summary: Search for contacts with Htek Phones
       description: |
-        **Required ACL:** `dird.directories.lookup.{profile}.{xivo_user_uuid}.read`
+        **Required ACL:** `dird.directories.lookup.{profile}.{user_uuid}.read`
 
         The `lookup` query will return a list of result matching the searched term
         formated for Htek Phones. The result will be retrieved from all configured
@@ -30,7 +30,7 @@ paths:
           $ref: '#/responses/AnotherServiceUnavailable'
       parameters:
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/Term'
       - $ref: '#/parameters/Limit'
       - $ref: '#/parameters/Offset'

--- a/wazo_dird/plugins/htek/plugin.py
+++ b/wazo_dird/plugins/htek/plugin.py
@@ -12,7 +12,7 @@ CONTENT_TYPE = 'text/xml'
 
 class HtekViewPlugin(BaseViewPlugin):
 
-    htek_lookup = '/directories/lookup/<profile>/<xivo_user_uuid>/htek'
+    htek_lookup = '/directories/lookup/<profile>/<user_uuid>/htek'
 
     def load(self, dependencies):
         api = dependencies['api']

--- a/wazo_dird/plugins/lookup_service/plugin.py
+++ b/wazo_dird/plugins/lookup_service/plugin.py
@@ -55,14 +55,15 @@ class _LookupService(helpers.BaseService):
         return future
 
     def lookup(
-        self, profile_config, tenant_uuid, term, xivo_user_uuid, args=None, token=None
+        self, profile_config, tenant_uuid, term, user_uuid, args=None, token=None
     ):
         args = args or {}
         futures = []
         sources = self.source_from_profile(profile_config)
         for source in sources:
             args['token'] = token
-            args['xivo_user_uuid'] = xivo_user_uuid
+            args['user_uuid'] = user_uuid
+            args['xivo_user_uuid'] = user_uuid
             futures.append(self._async_search(source, term, args))
 
         params = {'return_when': ALL_COMPLETED}

--- a/wazo_dird/plugins/office365_backend/plugin.py
+++ b/wazo_dird/plugins/office365_backend/plugin.py
@@ -149,12 +149,12 @@ class Office365Plugin(BaseSourcePlugin):
 
         return False
 
-    def _get_microsoft_token(self, xivo_user_uuid, token=None, **ignored):
+    def _get_microsoft_token(self, user_uuid, token=None, **ignored):
         if not token:
             logger.debug('Unable to search through Office365 without a token.')
             raise MicrosoftTokenNotFoundException()
 
-        return services.get_microsoft_access_token(xivo_user_uuid, token, **self.auth)
+        return services.get_microsoft_access_token(user_uuid, token, **self.auth)
 
     @staticmethod
     def _update_contact_fields(contacts):

--- a/wazo_dird/plugins/personal_backend/plugin.py
+++ b/wazo_dird/plugins/personal_backend/plugin.py
@@ -47,13 +47,13 @@ class PersonalBackend(BaseSourcePlugin):
 
     def search(self, term, args=None):
         logger.debug('Searching personal contacts with %s', term)
-        user_uuid = args['xivo_user_uuid']
+        user_uuid = args['user_uuid']
         matching_contacts = self._search_engine.find_personal_contacts(user_uuid, term)
         return self.format_contacts(matching_contacts)
 
     def first_match(self, term, args=None):
         logger.debug('First matching personal contacts with %s', term)
-        user_uuid = args['xivo_user_uuid']
+        user_uuid = args['user_uuid']
         matching_contacts = self._search_engine.find_first_personal_contact(
             user_uuid, term
         )
@@ -62,7 +62,7 @@ class PersonalBackend(BaseSourcePlugin):
 
     def list(self, source_entry_ids, args):
         logger.debug('Listing personal contacts: %s', source_entry_ids)
-        user_uuid = args['token_infos']['xivo_user_uuid']
+        user_uuid = args['user_uuid']
         matching_contacts = self._search_engine.list_personal_contacts(
             user_uuid, source_entry_ids
         )

--- a/wazo_dird/plugins/personal_backend/tests/test_personal_backend.py
+++ b/wazo_dird/plugins/personal_backend/tests/test_personal_backend.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that
@@ -31,7 +31,7 @@ class TestPersonalBackend(TestCase):
         self._search_engine.list_personal_contacts.return_value = [CONTACT_1, CONTACT_2]
 
         self._source.list(
-            ids, {'token_infos': {'token': 'valid-token', 'xivo_user_uuid': SOME_UUID}}
+            ids, {'user_uuid': SOME_UUID, 'token_infos': {'token': 'valid-token'}}
         )
 
         self._search_engine.list_personal_contacts.assert_called_once_with(
@@ -42,8 +42,7 @@ class TestPersonalBackend(TestCase):
         self._search_engine.list_personal_contacts.return_value = [CONTACT_1]
 
         result = self._source.list(
-            ['1'],
-            {'token_infos': {'token': 'valid-token', 'xivo_user_uuid': SOME_UUID}},
+            ['1'], {'user_uuid': SOME_UUID, 'token_infos': {'token': 'valid-token'}}
         )
 
         assert_that(result, has_item(has_property('is_personal', True)))
@@ -52,9 +51,7 @@ class TestPersonalBackend(TestCase):
     def test_that_search_calls_find_personal_contacts(self):
         self._search_engine.find_personal_contacts.return_value = [CONTACT_1]
 
-        self._source.search(
-            'alice', {'token': 'valid-token', 'xivo_user_uuid': SOME_UUID}
-        )
+        self._source.search('alice', {'token': 'valid-token', 'user_uuid': SOME_UUID})
 
         self._search_engine.find_personal_contacts.assert_called_once_with(
             SOME_UUID, 'alice'
@@ -64,7 +61,7 @@ class TestPersonalBackend(TestCase):
         self._search_engine.find_first_personal_contact.return_value = [CONTACT_1]
 
         result = self._source.first_match(
-            '555', {'token': 'valid-token', 'xivo_user_uuid': SOME_UUID}
+            '555', {'token': 'valid-token', 'user_uuid': SOME_UUID}
         )
 
         self._search_engine.find_first_personal_contact.assert_called_once_with(
@@ -76,7 +73,7 @@ class TestPersonalBackend(TestCase):
         self._search_engine.find_first_personal_contact.return_value = []
 
         result = self._source.first_match(
-            '555', {'token': 'valid-token', 'xivo_user_uuid': SOME_UUID}
+            '555', {'token': 'valid-token', 'user_uuid': SOME_UUID}
         )
 
         self._search_engine.find_first_personal_contact.assert_called_once_with(

--- a/wazo_dird/plugins/phone/http.py
+++ b/wazo_dird/plugins/phone/http.py
@@ -29,10 +29,11 @@ class PhoneMenu(LegacyAuthResource):
 
     @required_acl('dird.directories.menu.{profile}.{xivo_user_uuid}.read')
     def get(self, profile, xivo_user_uuid):
+        user_uuid = xivo_user_uuid
         proxy_url = request.headers.get('Proxy-URL', _build_next_url('menu'))
 
         response_xml = render_template(
-            self.template, xivo_proxy_url=proxy_url, xivo_user_uuid=xivo_user_uuid
+            self.template, xivo_proxy_url=proxy_url, xivo_user_uuid=user_uuid
         )
 
         return Response(response_xml, content_type=self.content_type, status=200)
@@ -45,10 +46,11 @@ class PhoneInput(LegacyAuthResource):
 
     @required_acl('dird.directories.input.{profile}.{xivo_user_uuid}.read')
     def get(self, profile, xivo_user_uuid):
+        user_uuid = xivo_user_uuid
         proxy_url = request.headers.get('Proxy-URL', _build_next_url('input'))
 
         response_xml = render_template(
-            self.template, xivo_proxy_url=proxy_url, xivo_user_uuid=xivo_user_uuid
+            self.template, xivo_proxy_url=proxy_url, xivo_user_uuid=user_uuid
         )
 
         return Response(response_xml, content_type=self.content_type, status=200)
@@ -85,6 +87,7 @@ class PhoneLookup(LegacyAuthResource):
 
     @required_acl('dird.directories.lookup.{profile}.{xivo_user_uuid}.read')
     def get(self, profile, xivo_user_uuid):
+        user_uuid = xivo_user_uuid
         args = self.parser.parse_args()
         term = args['term']
         offset = args['offset']
@@ -93,7 +96,7 @@ class PhoneLookup(LegacyAuthResource):
         token = request.headers['X-Auth-Token']
 
         try:
-            tenant_uuid = self._get_user_tenant_uuid(xivo_user_uuid)
+            tenant_uuid = self._get_user_tenant_uuid(user_uuid)
             profile_config = self.phone_lookup_service.profile_service.get_by_name(
                 tenant_uuid, profile
             )
@@ -106,7 +109,7 @@ class PhoneLookup(LegacyAuthResource):
                 profile_config,
                 term,
                 tenant_uuid,
-                user_uuid=xivo_user_uuid,
+                user_uuid=user_uuid,
                 token=token,
                 limit=limit,
                 offset=offset,
@@ -121,7 +124,7 @@ class PhoneLookup(LegacyAuthResource):
             self.template,
             results=results['results'],
             xivo_proxy_url=proxy_url,
-            xivo_user_uuid=xivo_user_uuid,
+            xivo_user_uuid=user_uuid,
             term=term,
             limit=limit,
             total=results['total'],

--- a/wazo_dird/plugins/phone/http.py
+++ b/wazo_dird/plugins/phone/http.py
@@ -27,9 +27,8 @@ class PhoneMenu(LegacyAuthResource):
         self.template = template
         self.content_type = content_type
 
-    @required_acl('dird.directories.menu.{profile}.{xivo_user_uuid}.read')
-    def get(self, profile, xivo_user_uuid):
-        user_uuid = xivo_user_uuid
+    @required_acl('dird.directories.menu.{profile}.{user_uuid}.read')
+    def get(self, profile, user_uuid):
         proxy_url = request.headers.get('Proxy-URL', _build_next_url('menu'))
 
         response_xml = render_template(
@@ -44,9 +43,8 @@ class PhoneInput(LegacyAuthResource):
         self.template = template
         self.content_type = content_type
 
-    @required_acl('dird.directories.input.{profile}.{xivo_user_uuid}.read')
-    def get(self, profile, xivo_user_uuid):
-        user_uuid = xivo_user_uuid
+    @required_acl('dird.directories.input.{profile}.{user_uuid}.read')
+    def get(self, profile, user_uuid):
         proxy_url = request.headers.get('Proxy-URL', _build_next_url('input'))
 
         response_xml = render_template(
@@ -85,9 +83,8 @@ class PhoneLookup(LegacyAuthResource):
             'term', type=str, required=True, help='term is missing', location='args'
         )
 
-    @required_acl('dird.directories.lookup.{profile}.{xivo_user_uuid}.read')
-    def get(self, profile, xivo_user_uuid):
-        user_uuid = xivo_user_uuid
+    @required_acl('dird.directories.lookup.{profile}.{user_uuid}.read')
+    def get(self, profile, user_uuid):
         args = self.parser.parse_args()
         term = args['term']
         offset = args['offset']

--- a/wazo_dird/plugins/phone_helpers.py
+++ b/wazo_dird/plugins/phone_helpers.py
@@ -34,12 +34,7 @@ class _PhoneLookupService:
         formatter = _PhoneResultFormatter(display)
 
         lookup_results = self._lookup_service.lookup(
-            profile_config,
-            tenant_uuid,
-            term,
-            xivo_user_uuid=user_uuid,
-            args={},
-            token=token,
+            profile_config, tenant_uuid, term, user_uuid=user_uuid, args={}, token=token
         )
         formatted_results = formatter.format_results(lookup_results)
         formatted_results.sort(key=attrgetter('name', 'number'))

--- a/wazo_dird/plugins/polycom/api.yml
+++ b/wazo_dird/plugins/polycom/api.yml
@@ -1,9 +1,9 @@
 paths:
-  /directories/input/{profile}/{xivo_user_uuid}/polycom:
+  /directories/input/{profile}/{user_uuid}/polycom:
     get:
       summary: Given informations about how make request lookup for Polycom Phones
       description: |
-        **Required ACL:** `dird.directories.input.{profile}.{xivo_user_uuid}.read`
+        **Required ACL:** `dird.directories.input.{profile}.{user_uuid}.read`
 
         The `input` query will return a XML to give informations about how make request
         lookup for Polycom Phones.
@@ -30,14 +30,14 @@ paths:
           $ref: '#/responses/AnotherServiceUnavailable'
       parameters:
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/ProxyUrl'
       - $ref: '#/parameters/AcceptLanguage'
-  /directories/lookup/{profile}/{xivo_user_uuid}/polycom:
+  /directories/lookup/{profile}/{user_uuid}/polycom:
     get:
       summary: Search for contacts with Polycom Phones
       description: |
-        **Required ACL:** `dird.directories.lookup.{profile}.{xivo_user_uuid}.read`
+        **Required ACL:** `dird.directories.lookup.{profile}.{user_uuid}.read`
 
         The `lookup` query will return a list of result matching the searched term
         formated for Polycom Phones. The result will be retrieved from all configured
@@ -70,7 +70,7 @@ paths:
           $ref: '#/responses/AnotherServiceUnavailable'
       parameters:
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/Term'
       - $ref: '#/parameters/Limit16'
       - $ref: '#/parameters/Offset'

--- a/wazo_dird/plugins/polycom/plugin.py
+++ b/wazo_dird/plugins/polycom/plugin.py
@@ -14,8 +14,8 @@ MAX_ITEM_PER_PAGE = 16
 
 class PolycomViewPlugin(BaseViewPlugin):
 
-    polycom_input = '/directories/input/<profile>/<xivo_user_uuid>/polycom'
-    polycom_lookup = '/directories/lookup/<profile>/<xivo_user_uuid>/polycom'
+    polycom_input = '/directories/input/<profile>/<user_uuid>/polycom'
+    polycom_lookup = '/directories/lookup/<profile>/<user_uuid>/polycom'
 
     def load(self, dependencies):
         api = dependencies['api']

--- a/wazo_dird/plugins/reverse_service/plugin.py
+++ b/wazo_dird/plugins/reverse_service/plugin.py
@@ -49,7 +49,7 @@ class _ReverseService(helpers.BaseService):
         self._executor.shutdown()
 
     def reverse(
-        self, profile_config, exten, profile, args=None, xivo_user_uuid=None, token=None
+        self, profile_config, exten, profile, args=None, user_uuid=None, token=None
     ):
         args = args or {}
         futures = []
@@ -61,7 +61,9 @@ class _ReverseService(helpers.BaseService):
         )
         for source in sources:
             args['token'] = token
-            args['xivo_user_uuid'] = xivo_user_uuid
+            args['user_uuid'] = user_uuid
+            # To avoid breaking plugins which used the xivo_user_uuid
+            args['xivo_user_uuid'] = user_uuid
             futures.append(self._async_reverse(source, exten, args))
 
         params = {}

--- a/wazo_dird/plugins/snom/api.yml
+++ b/wazo_dird/plugins/snom/api.yml
@@ -1,9 +1,9 @@
 paths:
-  /directories/input/{profile}/{xivo_user_uuid}/snom:
+  /directories/input/{profile}/{user_uuid}/snom:
     get:
       summary: Given informations about how make request lookup for Snom Phones
       description: |
-        **Required ACL:** `dird.directories.input.{profile}.{xivo_user_uuid}.read`
+        **Required ACL:** `dird.directories.input.{profile}.{user_uuid}.read`
 
         The `input` query will return a XML to give informations about how make request
         lookup for Snom Phones.
@@ -22,14 +22,14 @@ paths:
           $ref: '#/responses/AnotherServiceUnavailable'
       parameters:
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/ProxyUrl'
       - $ref: '#/parameters/AcceptLanguage'
-  /directories/lookup/{profile}/{xivo_user_uuid}/snom:
+  /directories/lookup/{profile}/{user_uuid}/snom:
     get:
       summary: Search for contacts with Snom Phones
       description: |
-        **Required ACL:** `dird.directories.lookup.{profile}.{xivo_user_uuid}.read`
+        **Required ACL:** `dird.directories.lookup.{profile}.{user_uuid}.read`
 
         The `lookup` query will return a list of result matching the searched term
         formated for Snom Phones. The result will be retrieved from all configured
@@ -56,7 +56,7 @@ paths:
           $ref: '#/responses/AnotherServiceUnavailable'
       parameters:
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/Term'
       - $ref: '#/parameters/Limit16'
       - $ref: '#/parameters/Offset'

--- a/wazo_dird/plugins/snom/plugin.py
+++ b/wazo_dird/plugins/snom/plugin.py
@@ -14,8 +14,8 @@ MAX_ITEM_PER_PAGE = 16
 
 class SnomViewPlugin(BaseViewPlugin):
 
-    snom_input = '/directories/input/<profile>/<xivo_user_uuid>/snom'
-    snom_lookup = '/directories/lookup/<profile>/<xivo_user_uuid>/snom'
+    snom_input = '/directories/input/<profile>/<user_uuid>/snom'
+    snom_lookup = '/directories/lookup/<profile>/<user_uuid>/snom'
 
     def load(self, dependencies):
         api = dependencies['api']

--- a/wazo_dird/plugins/thomson/api.yml
+++ b/wazo_dird/plugins/thomson/api.yml
@@ -1,9 +1,9 @@
 paths:
-  /directories/lookup/{profile}/{xivo_user_uuid}/thomson:
+  /directories/lookup/{profile}/{user_uuid}/thomson:
     get:
       summary: Search for contacts with Thomson Phones
       description: |
-        **Required ACL:** `dird.directories.lookup.{profile}.{xivo_user_uuid}.read`
+        **Required ACL:** `dird.directories.lookup.{profile}.{user_uuid}.read`
 
         The `lookup` query will return a list of result matching the searched term
         formated for Thomson Phones. The result will be retrieved from all configured
@@ -30,7 +30,7 @@ paths:
           $ref: '#/responses/AnotherServiceUnavailable'
       parameters:
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/Term'
       - $ref: '#/parameters/Limit8'
       - $ref: '#/parameters/Offset'

--- a/wazo_dird/plugins/thomson/plugin.py
+++ b/wazo_dird/plugins/thomson/plugin.py
@@ -13,7 +13,7 @@ MAX_ITEM_PER_PAGE = 8
 
 class ThomsonViewPlugin(BaseViewPlugin):
 
-    thomson_lookup = '/directories/lookup/<profile>/<xivo_user_uuid>/thomson'
+    thomson_lookup = '/directories/lookup/<profile>/<user_uuid>/thomson'
 
     def load(self, dependencies):
         api = dependencies['api']

--- a/wazo_dird/plugins/yealink/api.yml
+++ b/wazo_dird/plugins/yealink/api.yml
@@ -1,9 +1,9 @@
 paths:
-  /directories/lookup/{profile}/{xivo_user_uuid}/yealink:
+  /directories/lookup/{profile}/{user_uuid}/yealink:
     get:
       summary: Search for contacts with Yealink Phones
       description: |
-        **Required ACL:** `dird.directories.lookup.{profile}.{xivo_user_uuid}.read`
+        **Required ACL:** `dird.directories.lookup.{profile}.{user_uuid}.read`
 
         The `lookup` query will return a list of result matching the searched term
         formated for Yealink Phones. The result will be retrieved from all configured
@@ -30,7 +30,7 @@ paths:
           $ref: '#/responses/AnotherServiceUnavailable'
       parameters:
       - $ref: '#/parameters/Profile'
-      - $ref: '#/parameters/XivoUserUUID'
+      - $ref: '#/parameters/UserUUID'
       - $ref: '#/parameters/Term'
       - $ref: '#/parameters/Limit'
       - $ref: '#/parameters/Offset'

--- a/wazo_dird/plugins/yealink/plugin.py
+++ b/wazo_dird/plugins/yealink/plugin.py
@@ -12,7 +12,7 @@ CONTENT_TYPE = 'text/xml'
 
 class YealinkViewPlugin(BaseViewPlugin):
 
-    yealink_lookup = '/directories/lookup/<profile>/<xivo_user_uuid>/yealink'
+    yealink_lookup = '/directories/lookup/<profile>/<user_uuid>/yealink'
 
     def load(self, dependencies):
         api = dependencies['api']


### PR DESCRIPTION
the xivo_user_uuid has been deprecated and remove from our auth mock. I used the
user uuid instead of the pbx_user_uuid because a "normal" user could have
contacts without having a configured line.