### PR TITLE
integration tests: fix race condition for late_confd

### DIFF
--- a/integration_tests/assets/confd_data/asset.wazo_users_late_confd/run_confd
+++ b/integration_tests/assets/confd_data/asset.wazo_users_late_confd/run_confd
@@ -1,5 +1,8 @@
 #!/bin/sh
 
-sleep 10
+while [ ! -e /var/local/start-confd ] ; do
+    echo "Waiting for file /var/local/start-confd"
+    sleep 1
+done
 cd /tmp
 python -m SimpleHTTPServer 9486

--- a/integration_tests/suite/test_wazo_user_backend.py
+++ b/integration_tests/suite/test_wazo_user_backend.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from mock import Mock
@@ -121,6 +121,8 @@ class TestWazoUserLateConfd(BaseDirdIntegrationTest):
         result = self.lookup('dyl', 'default')
         assert_that(result['results'], contains())
 
+        self.docker_exec(['touch', '/var/local/start-confd'], service_name='america')
+
         def test():
             result = self.lookup('dyl', 'default')
             assert_that(
@@ -130,7 +132,7 @@ class TestWazoUserLateConfd(BaseDirdIntegrationTest):
                 ),
             )
 
-        until.assert_(test, tries=10)
+        until.assert_(test, timeout=10)
 
 
 class TestWazoUserMultipleWazo(BaseDirdIntegrationTest):


### PR DESCRIPTION
Why:

* Sometimes, the test would fail because late_confd would start too
early in the test