### PR TITLE
reverse: dont cancel other reverse upon failure

### DIFF
--- a/integration_tests/assets/etc/wazo-dird/conf.d/asset.half_broken.yml
+++ b/integration_tests/assets/etc/wazo-dird/conf.d/asset.half_broken.yml
@@ -1,6 +1,8 @@
 enabled_plugins:
   backends:
     broken_lookup: true
+    chained_broken_first_lookup: true
+    chained_second_lookup: true
 
 bus:
   enabled: false

--- a/integration_tests/docker/broken-plugins/setup.py
+++ b/integration_tests/docker/broken-plugins/setup.py
@@ -15,6 +15,8 @@ setup(
         'wazo_dird.backends': [
             'broken = xivo_dird_broken_plugins.broken_backend:BrokenPlugin',
             'broken_lookup = xivo_dird_broken_plugins.broken_backend:BrokenLookup',
+            'chained_broken_first_lookup = xivo_dird_broken_plugins.broken_backend:ChainedBrokenFirstLookup',
+            'chained_second_lookup = xivo_dird_broken_plugins.broken_backend:ChainedSecondLookup',
         ]
     },
 )

--- a/integration_tests/docker/broken-plugins/xivo_dird_broken_plugins/broken_backend.py
+++ b/integration_tests/docker/broken-plugins/xivo_dird_broken_plugins/broken_backend.py
@@ -1,5 +1,11 @@
-# Copyright 2015-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+import time
+import threading
+from wazo_dird.plugins.source_result import make_result_class
+
+first_lock = threading.Lock()
 
 
 class BrokenPlugin:
@@ -16,3 +22,30 @@ class BrokenLookup:
 
     def list(self, source_entry_id, args=None):
         raise RuntimeError('This backend is broken')
+
+
+class ChainedBrokenFirstLookup:
+    def load(self, config):
+        first_lock.acquire()
+        return
+
+    def first_match(self, term, args=None):
+        first_lock.release()
+        raise RuntimeError('This backend is broken')
+
+
+class ChainedSecondLookup:
+    def load(self, config):
+        self.SourceResult = make_result_class(
+            'chained-second-lookup-backend', 'chained-second-lookup'
+        )
+        return
+
+    def _ensure_first_lookup_has_ended(self):
+        first_lock.acquire()
+        first_lock.release()
+        time.sleep(0.1)
+
+    def first_match(self, term, args=None):
+        self._ensure_first_lookup_has_ended()
+        return self.SourceResult({'number': '5555555555', 'reverse': 'Second Lookup'})

--- a/integration_tests/suite/helpers/config.py
+++ b/integration_tests/suite/helpers/config.py
@@ -272,7 +272,13 @@ def new_half_broken_config(Session):
         name='default',
         display='default_display',
         services={
-            'lookup': {'sources': ['my_csv', 'broken', 'my_other_csv'], 'timeout': 0.5},
+            'lookup': {
+                'sources': ['my_csv', 'broken', 'my_other_csv'],
+                'timeout': 0.5,
+            },
+            'reverse': {
+                'sources': ['chained_broken_first_lookup', 'chained_second_lookup']
+            },
             'favorites': {'sources': ['my_csv', 'broken', 'my_other_csv']},
         },
     )
@@ -294,6 +300,10 @@ def new_half_broken_config(Session):
         format_columns={'lastname': "{ln}", 'firstname': "{fn}", 'number': "{num}"},
     )
     config.with_source(backend='broken', name='broken')
+    config.with_source(
+        backend='chained_broken_first_lookup', name='chained_broken_first_lookup'
+    )
+    config.with_source(backend='chained_second_lookup', name='chained_second_lookup')
     return config
 
 

--- a/integration_tests/suite/test_core_functionality.py
+++ b/integration_tests/suite/test_core_functionality.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -182,6 +182,13 @@ class TestLookupWhenASourceFails(HalfBrokenTestCase):
         assert_that(
             result['results'][1]['column_values'],
             contains('Alice', 'AAA', '5555555555'),
+        )
+
+    def test_that_reverse_returns_a_result(self):
+        result = self.reverse('5555555555', 'default', VALID_UUID)
+
+        assert_that(
+            result, has_entries({'display': 'Second Lookup', 'exten': '5555555555'})
         )
 
 

--- a/wazo_dird/plugins/reverse_service/plugin.py
+++ b/wazo_dird/plugins/reverse_service/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -82,7 +82,7 @@ class _ReverseService(helpers.BaseService):
             logger.info('Timeout on reverse lookup for exten: %s', exten)
 
     def _async_reverse(self, source, exten, args):
-        raise_stopper = helpers.RaiseStopper(return_on_raise=[])
+        raise_stopper = helpers.RaiseStopper(return_on_raise=None)
         future = self._executor.submit(
             raise_stopper.execute, source.first_match, exten, args
         )


### PR DESCRIPTION
Why:

* If one reverse source fails, it would cancel other reverse sources,
because `[]` is not `None`.

How:

* The tests try to reverse lookup on a broken source first, then on a
valid source. The code does not guarantee 100% that the broken source runs
first, but the lock coupled with time.sleep should be enough.