### PR TITLE
graphql: fix root query detection

### DIFF
--- a/wazo_dird/plugins/graphql/plugin.py
+++ b/wazo_dird/plugins/graphql/plugin.py
@@ -23,7 +23,7 @@ class AuthorizationMiddleware:
         self._auth_client = auth_client
 
     def _is_root_query(self, info):
-        return 'prev' not in info.path
+        return len(info.path) == 1
 
     def _is_authorized(self, info, token_id):
         root_field = info.field_name


### PR DESCRIPTION
Why:

* Querying { me { userUuid } } would return an Unauthorized error, even
if the ACL dird.graphql.me is allowed.
* This was probably introduced when switching to graphene

Depends-on: https://github.com/wazo-platform/xivo-test-helpers/pull/33