### PR TITLE
graphql: add contact field backend

### DIFF
--- a/integration_tests/suite/test_graphql.py
+++ b/integration_tests/suite/test_graphql.py
@@ -222,6 +222,7 @@ class TestGraphQL(BaseDirdIntegrationTest):
                                 lastname
                                 wazoReverse
                                 wazoSourceName
+                                wazoBackend
                             }
                         }
                     }
@@ -243,6 +244,7 @@ class TestGraphQL(BaseDirdIntegrationTest):
                             'lastname': 'AAA',
                             'wazoReverse': 'Alice AAA',
                             'wazoSourceName': any_of('my_csv', 'my_csv_2'),
+                            'wazoBackend': 'csv',
                         }
                     ),
                 ),

--- a/wazo_dird/plugins/graphql/resolver.py
+++ b/wazo_dird/plugins/graphql/resolver.py
@@ -55,3 +55,6 @@ class Resolver:
 
     def get_source_name(self, contact, info, **args):
         return contact.source
+
+    def get_backend(self, contact, info, **args):
+        return contact.backend

--- a/wazo_dird/plugins/graphql/schema.py
+++ b/wazo_dird/plugins/graphql/schema.py
@@ -13,6 +13,7 @@ def make_schema(resolver):
         lastname = Field(String)
         wazo_reverse = Field(String)
         wazo_source_name = Field(String)
+        wazo_backend = Field(String)
 
         def resolve_firstname(contact, info):
             return resolver.get_contact_field(contact, info)
@@ -25,6 +26,9 @@ def make_schema(resolver):
 
         def resolve_wazo_source_name(contact, info):
             return resolver.get_source_name(contact, info)
+
+        def resolve_wazo_backend(contact, info):
+            return resolver.get_backend(contact, info)
 
         def get_node(self, info, id):
             pass


### PR DESCRIPTION
Why:

* Distinguish contacts from a conference or wazo_user backend