### PR TITLE
wazo user backend: fix default values for auth/confd without https

### DIFF
--- a/integration_tests/suite/test_google_http.py
+++ b/integration_tests/suite/test_google_http.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -232,7 +232,7 @@ class TestPost(BaseGoogleCRUDTestCase):
                     uuid=uuid_(),
                     name='google',
                     auth=has_entries(
-                        host='localhost', port=9497, verify_certificate=True
+                        host='localhost', port=443, verify_certificate=True
                     ),
                 ),
             )

--- a/wazo_dird/plugins/wazo_user_backend/tests/test_schemas.py
+++ b/wazo_dird/plugins/wazo_user_backend/tests/test_schemas.py
@@ -37,7 +37,7 @@ class TestSourceSchema(TestCase):
                 format_columns=all_of(instance_of(dict), empty()),
                 auth=has_entries(
                     host='localhost',
-                    port=9497,
+                    port=443,
                     username='foo',
                     password='bar',
                     prefix='/api/auth',
@@ -46,7 +46,7 @@ class TestSourceSchema(TestCase):
                 ),
                 confd=has_entries(
                     host='localhost',
-                    port=9486,
+                    port=443,
                     prefix='/api/confd',
                     https=True,
                     verify_certificate=True,

--- a/wazo_dird/schemas.py
+++ b/wazo_dird/schemas.py
@@ -56,22 +56,22 @@ class BaseSourceSchema(BaseSchema):
 
 class ConfdConfigSchema(BaseSchema):
     host = fields.String(validate=Length(min=1, max=1024), missing='localhost')
-    port = fields.Integer(validate=Range(min=1, max=65535), missing=9486)
-    prefix = fields.String(allow_none=True, missing='/api/confd')
-    verify_certificate = VerifyCertificateField(missing=True)
-    timeout = fields.Float(validate=Range(min=0, max=3660))
+    port = fields.Integer(validate=Range(min=1, max=65535), missing=443)
     https = fields.Boolean(missing=True)
+    verify_certificate = VerifyCertificateField(missing=True)
+    prefix = fields.String(allow_none=True, missing='/api/confd')
     version = fields.String(validate=Length(min=1, max=16), missing='1.1')
+    timeout = fields.Float(validate=Range(min=0, max=3660))
 
 
 class BaseAuthConfigSchema(BaseSchema):
     host = fields.String(validate=Length(min=1, max=1024), missing='localhost')
-    port = fields.Integer(validate=Range(min=1, max=65535), missing=9497)
-    prefix = fields.String(allow_none=True, missing='/api/auth')
+    port = fields.Integer(validate=Range(min=1, max=65535), missing=443)
     https = fields.Boolean(missing=True)
     verify_certificate = VerifyCertificateField(missing=True)
-    timeout = fields.Float(validate=Range(min=0, max=3660))
+    prefix = fields.String(allow_none=True, missing='/api/auth')
     version = fields.String(validate=Length(min=1, max=16), missing='0.1')
+    timeout = fields.Float(validate=Range(min=0, max=3660))
 
 
 class AuthConfigSchema(BaseAuthConfigSchema):


### PR DESCRIPTION
Why:

* Default values would be incorrect for connecting to a real wazo
contact source.