### PR TITLE
fix default implementation of match_all

### DIFF
--- a/integration_tests/suite/test_dird_phonebook_backend.py
+++ b/integration_tests/suite/test_dird_phonebook_backend.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import random
@@ -111,6 +111,11 @@ class TestPhonebookBackend(unittest.TestCase):
         result = self.backend.first(self.draco['number'])
 
         assert_that(result, equal_to(self.draco))
+
+    def test_match_all_returns_the_expected_result(self):
+        result = self.backend.match_all([self.draco['number'], '999999'])
+
+        assert_that(result, contains_inanyorder(equal_to(self.draco)))
 
     def test_that_list_returns_the_contacts(self):
         result = self.backend.list(

--- a/wazo_dird/plugins/base_plugins.py
+++ b/wazo_dird/plugins/base_plugins.py
@@ -103,7 +103,9 @@ class BaseSourcePlugin(metaclass=abc.ABCMeta):
         """
         results = {}
         for exten in extens:
-            results[exten] = self.first_match(exten, args=args)
+            entry = self.first_match(exten, args=args)
+            if entry:
+                results[exten] = entry
         return results
 
     def list(self, uids, args):


### PR DESCRIPTION
the old behavior returned all results with None, what overwritten the
result for other sources