### PR TITLE
Pull request for WAZO-2177-duplicate-mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 21.01
+
+* Office365 and Google default source configuration has changed:
+
+  * Google: format column `phone = {numbers_except_label[mobile][0]}`
+  * Office365: format column `phone = {numbers_except_label[mobilePhone][0]}`
+
 ## 20.16
 
 * Backend plugins now implement a new method: `match_all()`

--- a/alembic/versions/29d00094fd68_google_office365_avoid_duplicate_number_.py
+++ b/alembic/versions/29d00094fd68_google_office365_avoid_duplicate_number_.py
@@ -1,0 +1,83 @@
+"""google/office365: avoid duplicate number in default columns
+
+Revision ID: 29d00094fd68
+Revises: 1bb9ba1188f4
+
+"""
+
+from alembic import op
+from sqlalchemy import sql
+
+
+# revision identifiers, used by Alembic.
+revision = '29d00094fd68'
+down_revision = '1bb9ba1188f4'
+
+dird_source_table = sql.table(
+    'dird_source',
+    sql.column('uuid'),
+    sql.column('format_columns'),
+    sql.column('backend'),
+)
+
+
+def upgrade():
+    dird_sources = get_google_sources()
+    for source in dird_sources:
+        update_google_source(source)
+
+    dird_sources = get_office365_sources()
+    for source in dird_sources:
+        update_office365_source(source)
+
+
+def get_google_sources():
+    google_sources = sql.select(
+        [
+            dird_source_table.c.uuid,
+            dird_source_table.c.format_columns,
+            dird_source_table.c.backend,
+        ]
+    ).where(dird_source_table.c.backend == 'google')
+    return op.get_bind().execute(google_sources)
+
+
+def update_google_source(source):
+    if source.format_columns['phone'] == '{numbers[0]}':
+        source.format_columns['phone'] = '{numbers_except_label[mobile][0]}'
+    query = (
+        dird_source_table.update()
+        .where(dird_source_table.c.uuid == source.uuid)
+        .values(
+            format_columns=source.format_columns,
+        )
+    )
+    op.get_bind().execute(query)
+
+
+def get_office365_sources():
+    office365_sources = sql.select(
+        [
+            dird_source_table.c.uuid,
+            dird_source_table.c.format_columns,
+            dird_source_table.c.backend,
+        ]
+    ).where(dird_source_table.c.backend == 'office365')
+    return op.get_bind().execute(office365_sources)
+
+
+def update_office365_source(source):
+    if source.format_columns['phone'] == '{numbers[0]}':
+        source.format_columns['phone'] = '{numbers_except_label[mobilePhone][0]}'
+    query = (
+        dird_source_table.update()
+        .where(dird_source_table.c.uuid == source.uuid)
+        .values(
+            format_columns=source.format_columns,
+        )
+    )
+    op.get_bind().execute(query)
+
+
+def downgrade():
+    pass

--- a/integration_tests/suite/test_auto_create.py
+++ b/integration_tests/suite/test_auto_create.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import kombu
@@ -153,7 +153,7 @@ class TestConfigAutoCreation(BaseDirdIntegrationTest):
                             format_columns=has_entries(
                                 phone_mobile='{numbers_by_label[mobile]}',
                                 reverse='{name}',
-                                phone='{numbers[0]}',
+                                phone='{numbers_except_label[mobile][0]}',
                             ),
                         )
                     )

--- a/wazo_dird/plugins/config_service/plugin.py
+++ b/wazo_dird/plugins/config_service/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -99,7 +99,7 @@ OFFICE_365_SOURCE_BODY = {
         'name': '{givenName} {surname}',
         'phone_mobile': '{mobilePhone}',
         'reverse': '{givenName} {surname}',
-        'phone': '{numbers[0]}',
+        'phone': '{numbers_except_label[mobilePhone][0]}',
     },
     'searched_columns': [
         'givenName',
@@ -122,7 +122,7 @@ GOOGLE_SOURCE_BODY = {
     'format_columns': {
         'phone_mobile': '{numbers_by_label[mobile]}',
         'reverse': '{name}',
-        'phone': '{numbers[0]}',
+        'phone': '{numbers_except_label[mobile][0]}',
     },
     'searched_columns': ['name', 'numbers', 'familyName', 'givenName'],
     'first_matched_columns': ['numbers'],

--- a/wazo_dird/plugins/google_backend/api.yml
+++ b/wazo_dird/plugins/google_backend/api.yml
@@ -71,7 +71,8 @@ paths:
 
         * name: the contact name
         * numbers: a list of phone numbers
-        * numbers_by_label: a map of type to numbers {'mobile': <number>, 'home': <number>}
+        * numbers_by_label: a map of type to numbers {'mobile': <number>, 'home': <number>, ...}. Types are defined by Google, currently known types include: 'home', 'work', 'mobile', 'other', 'main', 'home_fax', 'work_fax', 'google_voice', 'pager'.
+        * numbers_except_label: a map from type to every other number {'mobile': [<number>, <number], 'home': [<number>, <number>], ...}. See available types above. For example, the 'mobile' key will contain the 'work' and 'home' numbers, but will exclude the 'mobile' number.
         * emails: a list of email addresses
       tags:
         - configuration

--- a/wazo_dird/plugins/google_backend/services.py
+++ b/wazo_dird/plugins/google_backend/services.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -123,6 +123,7 @@ class ContactFormatter:
             'lastname': self._extract_last_name(contact),
             'numbers_by_label': self._extract_numbers_by_label(contact),
             'numbers': self._extract_numbers(contact),
+            'numbers_except_label': self._extract_numbers_except_label(contact),
             'emails': self._extract_emails(contact),
             'organizations': self._extract_organizations(contact),
             'addresses': self._extract_addresses(contact),
@@ -182,6 +183,28 @@ class ContactFormatter:
                 number = number.replace(char, '')
 
             numbers[type_] = number
+
+        return numbers
+
+    @classmethod
+    def _extract_numbers_except_label(cls, contact):
+        numbers_by_label = cls._extract_numbers_by_label(contact)
+        numbers = {}
+
+        for type_ in (
+            'home',
+            'work',
+            'mobile',
+            'other',
+            'main',
+            'home_fax',
+            'work_fax',
+            'google_voice',
+            'pager',
+        ):
+            candidates = dict(numbers_by_label)
+            candidates.pop(type_, None)
+            numbers[type_] = list(candidates.values())
 
         return numbers
 

--- a/wazo_dird/plugins/google_backend/tests/test_service.py
+++ b/wazo_dird/plugins/google_backend/tests/test_service.py
@@ -1,9 +1,9 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from hamcrest import assert_that, contains, contains_inanyorder, has_entries
+from hamcrest import assert_that, contains, contains_inanyorder, has_entries, has_items
 
 from .. import services
 
@@ -82,6 +82,10 @@ class TestGoogleContactFormatter(unittest.TestCase):
                 ),
                 numbers=contains_inanyorder(
                     '+15551239876', '5551231111', '+15551234567'
+                ),
+                numbers_except_label=has_entries(
+                    mobile=has_items('+15551239876', '5551231111'),
+                    home=has_items('+15551234567', '5551231111'),
                 ),
             ),
         )

--- a/wazo_dird/plugins/office365_backend/api.yml
+++ b/wazo_dird/plugins/office365_backend/api.yml
@@ -157,9 +157,9 @@ definitions:
     title: MicrosoftSource
     description: |
       In addition to the keys defined by the [Microsoft API](https://docs.microsoft.com/en-us/graph/api/resources/contact?view=graph-rest-1.0#),
-      `format_columns` also accepts a `numbers` field that aggregates the values from the
-      `businessPhones`, `homePhones` and `mobilePhone` fields.
-      Example: `"format_columns": {"number": "{numbers[0]}"}`
+      `format_columns` also accepts the following columns:
+      * a `numbers` field that aggregates the values from the `businessPhones`, `homePhones` and `mobilePhone` fields. Example: `"format_columns": {"phone": "{numbers[0]}"}`
+      * a `numbers_except_label` field that aggregates the same values than `numbers`, except for one field. Example: `"format_columns": {"phone": "{numbers_except_label[mobilePhone][0]}"}` will result in one of the phone numbers except the mobile phone.
     allOf:
       - $ref: '#/definitions/Source'
       - properties:

--- a/wazo_dird/plugins/office365_backend/plugin.py
+++ b/wazo_dird/plugins/office365_backend/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -184,4 +184,5 @@ class Office365Plugin(BaseSourcePlugin):
             contact.setdefault('givenName', '')
             contact['email'] = services.get_first_email(contact)
             contact['numbers'] = services.aggregate_numbers(contact)
+            contact['numbers_except_label'] = services.get_numbers_except_label(contact)
         return contacts

--- a/wazo_dird/plugins/office365_backend/services.py
+++ b/wazo_dird/plugins/office365_backend/services.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -36,6 +36,7 @@ class Office365Service(SelfSortingServiceMixin):
             response = requests.get(url, headers=headers, params={'$top': count})
             if response.status_code == 200:
                 logger.debug('Successfully fetched contacts from microsoft.')
+                logger.debug('Raw data: %s', response.text)
                 return response.json().get('value', [])
             else:
                 logger.error(

--- a/wazo_dird/plugins/office365_backend/services.py
+++ b/wazo_dird/plugins/office365_backend/services.py
@@ -16,7 +16,6 @@ from .exceptions import MicrosoftTokenNotFoundException, UnexpectedEndpointExcep
 
 logger = logging.getLogger(__name__)
 
-NUMBER_FIELDS = ('businessPhones', 'homePhones', 'mobilePhone')
 MULTI_PHONE_FIELDS = ('businessPhones', 'homePhones')
 SINGLE_PHONE_FIELDS = ('mobilePhone',)
 
@@ -121,13 +120,13 @@ def get_first_email(contact_information):
 
 def aggregate_numbers(contact):
     all_numbers = []
-    for field in NUMBER_FIELDS:
+    for field in SINGLE_PHONE_FIELDS:
         field_value = contact.get(field)
         if field_value:
-            if isinstance(field_value, list):
-                all_numbers.extend(field_value)
-            else:
-                all_numbers.append(field_value)
+            all_numbers.append(field_value)
+    for field in MULTI_PHONE_FIELDS:
+        field_value = contact.get(field) or []
+        all_numbers.extend(field_value)
     return all_numbers
 
 

--- a/wazo_dird/plugins/office365_backend/tests/test_office365_plugin.py
+++ b/wazo_dird/plugins/office365_backend/tests/test_office365_plugin.py
@@ -9,7 +9,6 @@ from hamcrest import (
     contains_inanyorder,
     empty,
     equal_to,
-    has_entry,
     has_entries,
     has_item,
     has_items,

--- a/wazo_dird/plugins/office365_backend/tests/test_office365_plugin.py
+++ b/wazo_dird/plugins/office365_backend/tests/test_office365_plugin.py
@@ -126,3 +126,31 @@ class TestOffice365Plugin(TestCase):
                 )
             ),
         )
+
+    def test_update_contact_fields_no_phone(self):
+        self.source.load(self.DEPENDENCIES)
+
+        mario = {
+            'name': 'Mario Bros',
+            'mobilePhone': None,
+            'businessPhones': [],
+            'homePhones': [],
+        }
+
+        assert_that(
+            self.source._update_contact_fields([mario]),
+            has_item(
+                has_entries(
+                    {
+                        'numbers': empty(),
+                        'numbers_except_label': has_entries(
+                            {
+                                'mobilePhone': empty(),
+                                'businessPhones': empty(),
+                                'homePhones': empty(),
+                            }
+                        ),
+                    }
+                )
+            ),
+        )

--- a/wazo_dird/plugins/office365_backend/tests/test_office365_plugin.py
+++ b/wazo_dird/plugins/office365_backend/tests/test_office365_plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 from unittest import TestCase
@@ -6,8 +6,11 @@ from unittest import TestCase
 from hamcrest import (
     assert_that,
     calling,
+    contains_inanyorder,
+    empty,
     equal_to,
     has_entry,
+    has_entries,
     has_item,
     has_items,
     not_,
@@ -80,7 +83,20 @@ class TestOffice365Plugin(TestCase):
 
         assert_that(
             self.source._update_contact_fields([mario]),
-            has_item(has_entry('numbers', has_items('1234', '567', '890', '111'))),
+            has_item(
+                has_entries(
+                    {
+                        'numbers': has_items('1234', '567', '890', '111'),
+                        'numbers_except_label': has_entries(
+                            {
+                                'mobilePhone': contains_inanyorder('567', '890', '111'),
+                                'businessPhones': contains_inanyorder('1234', '111'),
+                                'homePhones': contains_inanyorder('1234', '567', '890'),
+                            }
+                        ),
+                    }
+                )
+            ),
         )
 
     def test_update_contact_fields_one_phone(self):
@@ -95,5 +111,18 @@ class TestOffice365Plugin(TestCase):
 
         assert_that(
             self.source._update_contact_fields([mario]),
-            has_item(has_entry('numbers', has_item('111'))),
+            has_item(
+                has_entries(
+                    {
+                        'numbers': has_item('111'),
+                        'numbers_except_label': has_entries(
+                            {
+                                'mobilePhone': contains_inanyorder('111'),
+                                'businessPhones': contains_inanyorder('111'),
+                                'homePhones': empty(),
+                            }
+                        ),
+                    }
+                )
+            ),
         )


### PR DESCRIPTION
## google: display non-mobile numbers


## office365: add debug logs


## office365: add numbers_except_label

Why:

* avoid duplication mobile phone numbers

## migration: update default format columns for google/office365


## office365: split phone fields with single/multiple values