### PR TITLE
upgrade office356: accept missing default format column

### DIFF
--- a/alembic/versions/29d00094fd68_google_office365_avoid_duplicate_number_.py
+++ b/alembic/versions/29d00094fd68_google_office365_avoid_duplicate_number_.py
@@ -43,7 +43,7 @@ def get_google_sources():
 
 
 def update_google_source(source):
-    if source.format_columns['phone'] == '{numbers[0]}':
+    if source.format_columns.get('phone') == '{numbers[0]}':
         source.format_columns['phone'] = '{numbers_except_label[mobile][0]}'
     query = (
         dird_source_table.update()
@@ -67,7 +67,7 @@ def get_office365_sources():
 
 
 def update_office365_source(source):
-    if source.format_columns['phone'] == '{numbers[0]}':
+    if source.format_columns.get('phone') == '{numbers[0]}':
         source.format_columns['phone'] = '{numbers_except_label[mobilePhone][0]}'
     query = (
         dird_source_table.update()


### PR DESCRIPTION
Why:

* Office365 sources may not have a "phone" format column