### PR TITLE
use docker-compose from binary instead of python

### DIFF
--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -3,7 +3,6 @@ https://github.com/wazo-platform/xivo-bus/archive/master.zip
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
 https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
 
-docker-compose
 openapi-spec-validator
 pyhamcrest
 # pytest 4.2.0 has a bug: https://github.com/pytest-dev/pytest/issues/4700


### PR DESCRIPTION
why: to have the latest docker-compose