### PR TITLE
pin itsdangerous version

### DIFF
--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -21,6 +21,7 @@ stevedore
 flask-cors==3.0.7
 flask-restful==0.3.7
 flask==1.0.2
+itsdangerous==0.24  # from flask
 marshmallow==3.0.0b14
 werkzeug==0.14.1
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,11 @@ https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
 alembic==1.0.0
 cheroot==6.5.4
 flask-cors==3.0.7
-flask-restful==0.3.7
 flask-graphql==2.0.1
+flask-restful==0.3.7
 flask==1.0.2
 graphene==2.1.8
+itsdangerous==0.24  # from flask
 jinja2==2.10
 kombu==4.6.11
 marshmallow==3.0.0b14


### PR DESCRIPTION
why: if not pinned, pip install latest version (2.1.0) which is
incompatible with flask 1.0.2 from buster