### PR TITLE
WAZO-2723 requirements: pin markupsafe

### DIFF
--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -22,6 +22,8 @@ flask-cors==3.0.7
 flask-restful==0.3.7
 flask==1.0.2
 itsdangerous==0.24  # from flask
+jinja2==2.10  # from flask
+markupsafe==1.1.0  # from flask
 marshmallow==3.10.0
 werkzeug==0.14.1
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip


### PR DESCRIPTION
this avoids pulling a broken version when flasks will get installed