### PR TITLE
WAZO-3004: remove `downstream_exchange_declare`

### DIFF
--- a/integration_tests/suite/test_auto_create.py
+++ b/integration_tests/suite/test_auto_create.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -28,8 +28,12 @@ class TestConfigAutoCreation(BaseDirdIntegrationTest):
         self.tenant_uuid = SUB_TENANT
         self.tenant_name = 'mytenant'
         bus_port = self.service_port(5672, 'rabbitmq')
-        self.bus = BusClient.from_connection_fields(host='127.0.0.1', port=bus_port)
-        self.bus.downstream_exchange_declare('wazo-headers', 'headers')
+        self.bus = BusClient.from_connection_fields(
+            host='127.0.0.1',
+            port=bus_port,
+            exchange_name='wazo-headers',
+            exchange_type='headers',
+        )
 
         self.mock_auth_client = MockAuthClient(
             '127.0.0.1', self.service_port(9497, 'auth')

--- a/integration_tests/suite/test_personal.py
+++ b/integration_tests/suite/test_personal.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -54,8 +54,12 @@ class TestDeletedUser(BaseDirdIntegrationTest):
         super().setUp()
         until.true(self.bus_is_up, tries=10)
         bus_port = self.service_port(5672, 'rabbitmq')
-        self.bus = BusClient.from_connection_fields(host='127.0.0.1', port=bus_port)
-        self.bus.downstream_exchange_declare('wazo-headers', 'headers')
+        self.bus = BusClient.from_connection_fields(
+            host='127.0.0.1',
+            port=bus_port,
+            exchange_name='wazo-headers',
+            exchange_type='headers',
+        )
         until.true(self.bus.is_up, timeout=5)
 
     def test_that_deleting_a_user_deletes_its_storage(self):


### PR DESCRIPTION
Why:

* was used during transition from xivo -> wazo-headers
* no longer in use = dead code