### PR TITLE
remove swagger version in phonebook API plugin

### DIFF
--- a/wazo_dird/plugins/phonebook/api.yml
+++ b/wazo_dird/plugins/phonebook/api.yml
@@ -1,4 +1,3 @@
-swagger: '2.0.0'
 paths:
   /phonebooks:
     get:


### PR DESCRIPTION
why: redefines the global version found in API plugin,and breaks our reference documentation