### PR TITLE
plugins.phonebook_backend: fixed PhonebookSource definition

### DIFF
--- a/wazo_dird/plugins/phonebook_backend/api.yml
+++ b/wazo_dird/plugins/phonebook_backend/api.yml
@@ -156,8 +156,10 @@ definitions:
             type: string
           phonebook_name:
             type: string
+            readOnly: true
           phonebook_description:
             type: string
+            readOnly: true
       - required:
           - name
           - phonebook_uuid


### PR DESCRIPTION
phonebook openapi schema PhonebookSource definition has response-only attributes that must be set to `readOnly`, in accordance with actual marshmallow schemas.