### PR TITLE
displays: add columns to the default display

### DIFF
--- a/alembic/versions/042a2ba167c0_add_firstname_and_lastname_to_display.py
+++ b/alembic/versions/042a2ba167c0_add_firstname_and_lastname_to_display.py
@@ -1,0 +1,77 @@
+"""add firstname and lastname to display
+
+Revision ID: 042a2ba167c0
+Revises: 7c49d771407a
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '042a2ba167c0'
+down_revision = '7c49d771407a'
+
+display_tbl = sa.table(
+    'dird_display',
+    sa.column('uuid'),
+    sa.column('name'),
+)
+display_column_tbl = sa.table(
+    'dird_display_column',
+    sa.column('display_uuid'),
+    sa.column('field'),
+    sa.column('title'),
+    sa.column('type'),
+)
+
+
+def add_display_column(display_uuid, field, title):
+    type_ = field
+    op.execute(
+        display_column_tbl.insert().values(
+            display_uuid=display_uuid,
+            field=field,
+            title=title,
+            type=type_,
+        )
+    )
+
+
+def list_default_displays():
+    query = sa.sql.select([display_tbl.c.uuid]).where(
+        display_tbl.c.name.startswith('auto_'),
+    )
+    return {row.uuid for row in op.get_bind().execute(query)}
+
+
+def list_display_uuid_by_field(field_name):
+    query = sa.sql.select([display_column_tbl.c.display_uuid]).where(
+        display_column_tbl.c.field == field_name,
+    )
+    return {row.display_uuid for row in op.get_bind().execute(query)}
+
+
+def list_displays_with_firstname():
+    return list_display_uuid_by_field('firstname')
+
+
+def list_displays_with_lastname():
+    return list_display_uuid_by_field('lastname')
+
+
+def upgrade():
+    default_display_uuids = list_default_displays()
+    displays_with_firstname = list_displays_with_firstname()
+    displays_with_lastname = list_displays_with_lastname()
+    displays_requiring_firstname = default_display_uuids - displays_with_firstname
+    displays_requiring_lastname = default_display_uuids - displays_with_lastname
+    for display_uuid in displays_requiring_firstname:
+        add_display_column(display_uuid, 'firstname', 'Prénom')
+    for display_uuid in displays_requiring_lastname:
+        add_display_column(display_uuid, 'lastname', 'Nom de famille')
+
+
+def downgrade():
+    pass

--- a/integration_tests/suite/test_auto_create.py
+++ b/integration_tests/suite/test_auto_create.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains, contains_inanyorder, has_entries, has_item
@@ -187,15 +187,29 @@ class TestConfigAutoCreation(BaseDirdIntegrationTest):
                 result,
                 has_entries(
                     column_headers=contains(
-                        'Nom', 'Numéro', 'Mobile', 'Boîte vocale', 'Favoris', 'E-mail'
+                        'Nom',
+                        'Prénom',
+                        'Nom de famille',
+                        'Numéro',
+                        'Mobile',
+                        'Boîte vocale',
+                        'Favoris',
+                        'E-mail',
                     ),
                     column_types=contains(
-                        'name', 'number', 'number', 'voicemail', 'favorite', 'email'
+                        'name',
+                        'firstname',
+                        'lastname',
+                        'number',
+                        'number',
+                        'voicemail',
+                        'favorite',
+                        'email',
                     ),
                     results=contains_inanyorder(
                         has_entries(
                             column_values=contains(
-                                'Alice', '1234', None, None, False, None
+                                'Alice', 'Alice', None, '1234', None, None, False, None
                             )
                         )
                     ),

--- a/wazo_dird/plugins/config_service/plugin.py
+++ b/wazo_dird/plugins/config_service/plugin.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DISPLAY_COLUMNS = [
     {'field': 'name', 'title': 'Nom', 'type': 'name'},
+    {'field': 'firstname', 'title': 'Prénom', 'type': 'firstname'},
+    {'field': 'lastname', 'title': 'Nom de famille', 'type': 'lastname'},
     {
         'field': 'phone',
         'title': "Num\xE9ro",


### PR DESCRIPTION
the default displays auto generated for each tenant now includes the firstname and lastname columns

the goal is to allow an application more flexibility