### PR TITLE
Use marshmallow version 3.18.0 from Bookworm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ jinja2==3.0.3  # from flask
 jsonpatch==1.21
 kombu==5.0.2
 markupsafe==2.0.1 # from jinja
-marshmallow==3.10.0
+marshmallow==3.18.0
 psycopg2-binary==2.8.6
 python-consul==1.1.0
 python-ldap==3.2.0

--- a/wazo_dird/plugins/conference_backend/schemas.py
+++ b/wazo_dird/plugins/conference_backend/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import pre_dump
@@ -45,7 +45,7 @@ class ContactListSchema(_ListSchema):
     sort_columns = ['name']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
 
 class ListSchema(_ListSchema):
@@ -53,13 +53,15 @@ class ListSchema(_ListSchema):
     sort_columns = ['name']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
 
 class SourceSchema(BaseSourceSchema):
-    auth = fields.Nested(AuthConfigSchema, missing=lambda: AuthConfigSchema().load({}))
+    auth = fields.Nested(
+        AuthConfigSchema, load_default=lambda: AuthConfigSchema().load({})
+    )
     confd = fields.Nested(
-        ConfdConfigSchema, missing=lambda: ConfdConfigSchema().load({})
+        ConfdConfigSchema, load_default=lambda: ConfdConfigSchema().load({})
     )
 
 

--- a/wazo_dird/plugins/csv_backend/schemas.py
+++ b/wazo_dird/plugins/csv_backend/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.mallow import fields
@@ -12,10 +12,10 @@ class SourceSchema(BaseSourceSchema):
     unique_column = fields.String(
         validate=Length(min=1, max=128),
         allow_none=True,
-        missing=None,
+        load_default=None,
     )
     file = fields.String(validate=Length(min=1), required=True)
-    separator = fields.String(validate=Length(min=1, max=1), missing=',')
+    separator = fields.String(validate=Length(min=1, max=1), load_default=',')
 
 
 class ListSchema(_ListSchema):
@@ -23,7 +23,7 @@ class ListSchema(_ListSchema):
     sort_columns = ['name', 'file']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
 
 source_list_schema = SourceSchema(many=True)

--- a/wazo_dird/plugins/csv_ws_backend/schemas.py
+++ b/wazo_dird/plugins/csv_ws_backend/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.mallow import fields
@@ -10,12 +10,12 @@ from wazo_dird.schemas import BaseSourceSchema, VerifyCertificateField
 
 class SourceSchema(BaseSourceSchema):
     lookup_url = fields.URL(required=True)
-    list_url = fields.URL(allow_none=True, missing=None)
-    verify_certificate = VerifyCertificateField(missing=True)
-    delimiter = fields.String(validate=Length(min=1, max=1), missing=',')
-    timeout = fields.Float(validate=Range(min=0), missing=10.0)
+    list_url = fields.URL(allow_none=True, load_default=None)
+    verify_certificate = VerifyCertificateField(load_default=True)
+    delimiter = fields.String(validate=Length(min=1, max=1), load_default=',')
+    timeout = fields.Float(validate=Range(min=0), load_default=10.0)
     unique_column = fields.String(
-        validate=Length(min=1, max=128), allow_none=True, missing=None
+        validate=Length(min=1, max=128), allow_none=True, load_default=None
     )
 
 
@@ -24,7 +24,7 @@ class ListSchema(_ListSchema):
     sort_columns = ['name', 'lookup_url', 'list_url']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
 
 source_list_schema = SourceSchema(many=True)

--- a/wazo_dird/plugins/displays/schemas.py
+++ b/wazo_dird/plugins/displays/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.mallow import fields
@@ -12,7 +12,7 @@ class ListSchema(_ListSchema):
     sort_columns = ['name']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
 
 display_list_schema = DisplaySchema(many=True)

--- a/wazo_dird/plugins/google_backend/schemas.py
+++ b/wazo_dird/plugins/google_backend/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.mallow import fields
@@ -10,7 +10,7 @@ from wazo_dird.schemas import BaseAuthConfigSchema, BaseSourceSchema
 class SourceSchema(BaseSourceSchema):
     auth = fields.Nested(
         BaseAuthConfigSchema,
-        missing=lambda: BaseAuthConfigSchema().load({}),
+        load_default=lambda: BaseAuthConfigSchema().load({}),
     )
 
 
@@ -19,7 +19,7 @@ class ListSchema(_ListSchema):
     sort_columns = ['name']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
 
 class ContactListSchema(_ListSchema):

--- a/wazo_dird/plugins/ldap_backend/schemas.py
+++ b/wazo_dird/plugins/ldap_backend/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.mallow import fields
@@ -11,16 +11,18 @@ from wazo_dird.schemas import BaseSourceSchema
 class SourceSchema(BaseSourceSchema):
     ldap_uri = fields.String(validate=Length(min=1, max=256), required=True)
     ldap_base_dn = fields.String(validate=Length(min=1, max=1024), required=True)
-    ldap_username = fields.String(validate=Length(min=1), missing=None)
-    ldap_password = fields.String(validate=Length(min=1), missing=None)
-    ldap_custom_filter = fields.String(validate=Length(min=1, max=1024), missing=None)
-    ldap_network_timeout = fields.Float(validate=Range(min=0), default=0.3)
-    ldap_timeout = fields.Float(validate=Range(min=0), default=1.0)
+    ldap_username = fields.String(validate=Length(min=1), load_default=None)
+    ldap_password = fields.String(validate=Length(min=1), load_default=None)
+    ldap_custom_filter = fields.String(
+        validate=Length(min=1, max=1024), load_default=None
+    )
+    ldap_network_timeout = fields.Float(validate=Range(min=0), dump_default=0.3)
+    ldap_timeout = fields.Float(validate=Range(min=0), dump_default=1.0)
     unique_column = fields.String(
-        validate=Length(min=1, max=128), allow_none=True, missing=None
+        validate=Length(min=1, max=128), allow_none=True, load_default=None
     )
     unique_column_format = fields.String(
-        validate=OneOf(['string', 'binary_uuid']), missing='string'
+        validate=OneOf(['string', 'binary_uuid']), load_default='string'
     )
 
 
@@ -29,7 +31,7 @@ class ListSchema(_ListSchema):
     sort_columns = ['name', 'ldap_uri', 'ldap_base_dn', 'ldap_username']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
 
 source_list_schema = SourceSchema(many=True)

--- a/wazo_dird/plugins/office365_backend/schemas.py
+++ b/wazo_dird/plugins/office365_backend/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.mallow import fields
@@ -11,10 +11,10 @@ from wazo_dird.schemas import BaseAuthConfigSchema, BaseSourceSchema
 class SourceSchema(BaseSourceSchema):
     auth = fields.Nested(
         BaseAuthConfigSchema,
-        missing=lambda: BaseAuthConfigSchema().load({}),
+        load_default=lambda: BaseAuthConfigSchema().load({}),
     )
     endpoint = fields.String(
-        missing='https://graph.microsoft.com/v1.0/me/contacts',
+        load_default='https://graph.microsoft.com/v1.0/me/contacts',
         validate=Length(min=1, max=255),
     )
 
@@ -24,7 +24,7 @@ class ListSchema(_ListSchema):
     sort_columns = ['name']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
 
 class ContactListSchema(_ListSchema):

--- a/wazo_dird/plugins/personal_backend/schemas.py
+++ b/wazo_dird/plugins/personal_backend/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.mallow import fields
@@ -12,7 +12,7 @@ class ListSchema(_ListSchema):
     sort_columns = ['name']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
 
 source_list_schema = BaseSourceSchema(many=True)

--- a/wazo_dird/plugins/phonebook/schemas.py
+++ b/wazo_dird/plugins/phonebook/schemas.py
@@ -17,7 +17,7 @@ class ContactListSchema(ListSchema):
     sort_columns = ['firstname', 'lastname', 'name']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
     def load_count(self, args: dict, **kwargs) -> CountParams:
         return cast(CountParams, projection(self.load(args, **kwargs), ['search']))
@@ -31,7 +31,7 @@ class PhonebookListSchema(ListSchema):
     sort_columns = ['name', 'description']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
     def load_count(self, args: dict, **kwargs) -> CountParams:
         return cast(CountParams, projection(self.load(args, **kwargs), ['search']))

--- a/wazo_dird/plugins/phonebook_backend/schemas.py
+++ b/wazo_dird/plugins/phonebook_backend/schemas.py
@@ -29,7 +29,7 @@ class ListSchema(_ListSchema):
     sort_columns = ['name']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
 
 source_list_schema = SourceSchema(many=True)

--- a/wazo_dird/plugins/profiles/schemas.py
+++ b/wazo_dird/plugins/profiles/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.mallow import fields
@@ -13,8 +13,8 @@ class ResourceSchema(BaseSchema):
 
 
 class ServiceConfigSchema(BaseSchema):
-    sources = fields.Nested(ResourceSchema, many=True, missing=[])
-    options = fields.Dict(missing={})
+    sources = fields.Nested(ResourceSchema, many=True, load_default=[])
+    options = fields.Dict(load_default={})
 
 
 class ServiceDictSchema(fields.Nested):
@@ -50,7 +50,7 @@ class ListSchema(_ListSchema):
     sort_columns = ['name']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
 
 list_schema = ListSchema()

--- a/wazo_dird/plugins/sources/schemas.py
+++ b/wazo_dird/plugins/sources/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.mallow import fields
@@ -12,7 +12,7 @@ class ListSchema(_ListSchema):
     sort_columns = ['name', 'backend']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
 
 source_list_schema = SourceSchema(many=True)

--- a/wazo_dird/plugins/wazo_user_backend/schemas.py
+++ b/wazo_dird/plugins/wazo_user_backend/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.mallow import fields
@@ -13,9 +13,11 @@ from wazo_dird.schemas import (
 
 
 class SourceSchema(BaseSourceSchema):
-    auth = fields.Nested(AuthConfigSchema, missing=lambda: AuthConfigSchema().load({}))
+    auth = fields.Nested(
+        AuthConfigSchema, load_default=lambda: AuthConfigSchema().load({})
+    )
     confd = fields.Nested(
-        ConfdConfigSchema, missing=lambda: ConfdConfigSchema().load({})
+        ConfdConfigSchema, load_default=lambda: ConfdConfigSchema().load({})
     )
 
 
@@ -24,7 +26,7 @@ class ListSchema(_ListSchema):
     sort_columns = ['name']
     default_sort_column = 'name'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
 
 class ContactListSchema(_ListSchema):
@@ -32,7 +34,7 @@ class ContactListSchema(_ListSchema):
     sort_columns = ['firstname', 'lastname']
     default_sort_column = 'firstname'
 
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
     uuid = fields.String()
 
 

--- a/wazo_dird/schemas.py
+++ b/wazo_dird/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import exceptions, utils, validates_schema
@@ -28,31 +28,31 @@ class BaseSourceSchema(BaseSchema):
     tenant_uuid = fields.UUID(dump_only=True)
     name = fields.String(validate=Length(min=1, max=512), required=True)
     first_matched_columns = fields.List(
-        fields.String(validate=Length(min=1, max=128)), missing=[]
+        fields.String(validate=Length(min=1, max=128)), load_default=[]
     )
     searched_columns = fields.List(
-        fields.String(validate=Length(min=1, max=128)), missing=[]
+        fields.String(validate=Length(min=1, max=128)), load_default=[]
     )
-    format_columns = fields.Dict(validate=validate_string_dict, missing={})
+    format_columns = fields.Dict(validate=validate_string_dict, load_default={})
 
 
 class ConfdConfigSchema(BaseSchema):
-    host = fields.String(validate=Length(min=1, max=1024), missing='localhost')
-    port = fields.Integer(validate=Range(min=1, max=65535), missing=443)
-    https = fields.Boolean(missing=True)
-    verify_certificate = VerifyCertificateField(missing=True)
-    prefix = fields.String(allow_none=True, missing='/api/confd')
-    version = fields.String(validate=Length(min=1, max=16), missing='1.1')
+    host = fields.String(validate=Length(min=1, max=1024), load_default='localhost')
+    port = fields.Integer(validate=Range(min=1, max=65535), load_default=443)
+    https = fields.Boolean(load_default=True)
+    verify_certificate = VerifyCertificateField(load_default=True)
+    prefix = fields.String(allow_none=True, load_default='/api/confd')
+    version = fields.String(validate=Length(min=1, max=16), load_default='1.1')
     timeout = fields.Float(validate=Range(min=0, max=3660))
 
 
 class BaseAuthConfigSchema(BaseSchema):
-    host = fields.String(validate=Length(min=1, max=1024), missing='localhost')
-    port = fields.Integer(validate=Range(min=1, max=65535), missing=443)
-    https = fields.Boolean(missing=True)
-    verify_certificate = VerifyCertificateField(missing=True)
-    prefix = fields.String(allow_none=True, missing='/api/auth')
-    version = fields.String(validate=Length(min=1, max=16), missing='0.1')
+    host = fields.String(validate=Length(min=1, max=1024), load_default='localhost')
+    port = fields.Integer(validate=Range(min=1, max=65535), load_default=443)
+    https = fields.Boolean(load_default=True)
+    verify_certificate = VerifyCertificateField(load_default=True)
+    prefix = fields.String(allow_none=True, load_default='/api/auth')
+    version = fields.String(validate=Length(min=1, max=16), load_default='0.1')
     timeout = fields.Float(validate=Range(min=0, max=3660))
 
 


### PR DESCRIPTION
This change uses the Bookworm version of marshmallow to reduce the scope of changes that are going to happen when doing the upgrade