### PR TITLE
WAZO-3954 replace slashes in tenants' name

### DIFF
--- a/alembic/versions/4bd4e843802a_remove_slashes_from_phonebook_names.py
+++ b/alembic/versions/4bd4e843802a_remove_slashes_from_phonebook_names.py
@@ -1,0 +1,53 @@
+"""remove slashes from phonebook names
+
+Revision ID: 4bd4e843802a
+Revises: 2adc8aff56ea
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '4bd4e843802a'
+down_revision = '2adc8aff56ea'
+
+
+source_table = sa.table(
+    'dird_source',
+    sa.column('uuid'),
+    sa.column('name'),
+)
+
+display_table = sa.table(
+    'dird_display',
+    sa.column('uuid'),
+    sa.column('name'),
+)
+
+
+def upgrade():
+    source_query = sa.sql.select([source_table.c.uuid, source_table.c.name]).where(
+        source_table.c.name.contains('/')
+    )
+    display_query = sa.sql.select([display_table.c.uuid, display_table.c.name]).where(
+        display_table.c.name.contains('/')
+    )
+    for elem in op.get_bind().execute(source_query):
+        op.execute(
+            source_table.update()
+            .where(source_table.c.uuid == elem.uuid)
+            .values(name=elem.name.replace('/', '_'))
+        )
+
+    for elem in op.get_bind().execute(display_query):
+        op.execute(
+            display_table.update()
+            .where(display_table.c.uuid == elem.uuid)
+            .values(name=elem.name.replace('/', '_'))
+        )
+
+
+def downgrade():
+    pass

--- a/integration_tests/suite/test_displays.py
+++ b/integration_tests/suite/test_displays.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -249,6 +249,23 @@ class TestPost(BaseDisplayTestCase):
                             default=None,
                         ),
                     ),
+                ),
+            )
+
+    def test_slash_in_name(self):
+        body = {
+            'name': 'display/test',
+            'columns': [
+                {'field': 'fn', 'title': 'Firstname', 'default': ''},
+            ],
+        }
+        with self.create(self.client, body) as display:
+            assert_that(
+                display,
+                has_entries(
+                    uuid=uuid_(),
+                    tenant_uuid=MAIN_TENANT,
+                    name='display_test',
                 ),
             )
 

--- a/integration_tests/suite/test_sources.py
+++ b/integration_tests/suite/test_sources.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, calling, contains, contains_inanyorder, has_properties
@@ -16,6 +16,14 @@ from .helpers.fixtures import http as fixtures
 
 class TestList(BaseDirdIntegrationTest):
     asset = 'all_routes'
+
+    @fixtures.csv_source(name='ab/cd')
+    def test_create_with_slash(self, abcd):
+        result = self.client.sources.list(name='ab_cd')
+        print(result)
+        self.assert_list_result(
+            result, contains(self._source_to_dict('csv', **abcd)), total=1, filtered=1
+        )
 
     @fixtures.ldap_source(name='abc')
     @fixtures.personal_source(name='bcd')

--- a/wazo_dird/database/models.py
+++ b/wazo_dird/database/models.py
@@ -92,9 +92,17 @@ class Display(Base):
     tenant_uuid = Column(
         String(UUID_LENGTH), ForeignKey('dird_tenant.uuid', ondelete='CASCADE')
     )
-    name = Column(Text(), nullable=False)
+    _name = Column('name', Text(), nullable=False)
 
     columns = relationship('DisplayColumn', viewonly=True)
+
+    @hybrid_property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value.replace('/', '_')
 
 
 class DisplayColumn(Base):
@@ -307,7 +315,7 @@ class Source(Base):
                 self.uuid,
             )
         else:
-            self._name = value
+            self._name = value.replace('/', '_')
 
     @name.expression
     def name(cls):


### PR DESCRIPTION
Why: some APIs rely on the tenant's name and having a slash in it breaks the URL

